### PR TITLE
Normalize path joins with POSIX logic

### DIFF
--- a/src/utils/runtime.ts
+++ b/src/utils/runtime.ts
@@ -186,6 +186,9 @@ const runtimeInfo = detectRuntime();
 interface PathModule {
   join(...paths: string[]): string;
   resolve(...paths: string[]): string;
+  posix?: {
+    join(...paths: string[]): string;
+  };
 }
 
 let pathModule: PathModule | null = null;
@@ -205,10 +208,16 @@ export const pathUtils = {
    * Join paths in a cross-runtime way
    */
   join(...segments: string[]): string {
-    if (runtimeInfo.name === 'browser' || !pathModule?.join) {
-      return segments.join('/');
+    if (runtimeInfo.name === 'browser' || !pathModule) {
+      return segments.join('/').replace(/\\/g, '/');
     }
-    return pathModule.join(...segments);
+    if (pathModule.posix?.join) {
+      return pathModule.posix.join(...segments);
+    }
+    if (pathModule.join) {
+      return pathModule.join(...segments).replace(/\\/g, '/');
+    }
+    return segments.join('/').replace(/\\/g, '/');
   },
 
   /**

--- a/test/runtime_utils.test.ts
+++ b/test/runtime_utils.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import * as path from 'node:path';
 import { detectRuntime, pathUtils } from '../src/utils/runtime.js';
 
 describe('runtime utilities', () => {
@@ -10,7 +11,10 @@ describe('runtime utilities', () => {
 
   it('normalizes joined paths', () => {
     const joined = pathUtils.join('/foo', '.', 'bar');
+    const expected =
+      path.posix?.join('/foo', 'bar') ??
+      path.join('/foo', 'bar').replace(/\\/g, '/');
     expect(joined.includes('/./')).toBe(false);
-    expect(joined.endsWith('/foo/bar')).toBe(true);
+    expect(joined).toBe(expected);
   });
 });


### PR DESCRIPTION
## Summary
- Use `path.posix.join` when available and normalize backslashes otherwise
- Compute test expectations using the same normalization strategy

## Testing
- `npm test`
- `npm run lint src/utils/runtime.ts test/runtime_utils.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b33744fed88323a943564e5bcb88e9