### PR TITLE
feat: normalize paths in browser runtime

### DIFF
--- a/src/utils/runtime.ts
+++ b/src/utils/runtime.ts
@@ -206,7 +206,33 @@ export const pathUtils = {
    */
   join(...segments: string[]): string {
     if (runtimeInfo.name === 'browser' || !pathModule?.join) {
-      return segments.join('/');
+      const parts: string[] = [];
+      let absolute = false;
+
+      for (const segment of segments) {
+        if (!segment) {
+          continue;
+        }
+        if (segment.startsWith('/')) {
+          absolute = true;
+        }
+        for (const part of segment.split('/')) {
+          if (!part || part === '.') {
+            continue;
+          }
+          if (part === '..') {
+            if (parts.length && parts[parts.length - 1] !== '..') {
+              parts.pop();
+            } else if (!absolute) {
+              parts.push('..');
+            }
+            continue;
+          }
+          parts.push(part);
+        }
+      }
+
+      return `${absolute ? '/' : ''}${parts.join('/')}`;
     }
     return pathModule.join(...segments);
   },

--- a/test/runtime_utils.test.ts
+++ b/test/runtime_utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { detectRuntime, pathUtils } from '../src/utils/runtime.js';
 
 describe('runtime utilities', () => {
@@ -12,5 +12,21 @@ describe('runtime utilities', () => {
     const joined = pathUtils.join('/foo', '.', 'bar');
     expect(joined.includes('/./')).toBe(false);
     expect(joined.endsWith('/foo/bar')).toBe(true);
+  });
+
+  it('normalizes paths in browser-like runtime', async () => {
+    try {
+      vi.stubGlobal('process', undefined);
+      vi.stubGlobal('window', {} as unknown);
+      vi.resetModules();
+      const { pathUtils: browserPathUtils } = await import('../src/utils/runtime.js');
+      const joined = browserPathUtils.join('/foo', '.', 'bar', '..', 'baz');
+      expect(joined).toBe('/foo/baz');
+      const relative = browserPathUtils.join('foo', '..', 'bar');
+      expect(relative).toBe('bar');
+    } finally {
+      vi.unstubAllGlobals();
+      vi.resetModules();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- normalize `pathUtils.join` in non-Node runtimes to strip `.` and resolve `..`
- add tests simulating browser runtime verifying normalized joins

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3383c985c8323bf8516a3e6aeea5e