### PR TITLE
feat: lazily import path module

### DIFF
--- a/src/core/discovery.ts
+++ b/src/core/discovery.ts
@@ -104,8 +104,8 @@ export class ModuleDiscovery {
 
     for (const searchPath of searchPaths) {
       const candidates = [
-        pathUtils.join(searchPath, `${moduleName}.py`),
-        pathUtils.join(searchPath, moduleName, '__init__.py'),
+        await pathUtils.join(searchPath, `${moduleName}.py`),
+        await pathUtils.join(searchPath, moduleName, '__init__.py'),
       ];
 
       for (const candidate of candidates) {
@@ -275,8 +275,8 @@ export class ModuleDiscovery {
     // Add virtual environment paths
     if (this.options.virtualEnv) {
       paths.push(
-        pathUtils.join(this.options.virtualEnv, 'lib', 'python*', 'site-packages'),
-        pathUtils.join(this.options.virtualEnv, 'Lib', 'site-packages') // Windows
+        await pathUtils.join(this.options.virtualEnv, 'lib', 'python*', 'site-packages'),
+        await pathUtils.join(this.options.virtualEnv, 'Lib', 'site-packages') // Windows
       );
     }
 

--- a/src/tywrap.ts
+++ b/src/tywrap.ts
@@ -101,7 +101,7 @@ export async function generate(
         await modFs.mkdir(cacheDir, { recursive: true });
       } catch {}
       try {
-        const cached = await fsUtils.readFile(pathUtils.join(cacheDir, cacheKey));
+        const cached = await fsUtils.readFile(await pathUtils.join(cacheDir, cacheKey));
         ir = JSON.parse(cached);
       } catch {
         ir = null;
@@ -113,7 +113,7 @@ export async function generate(
       // Basic warning when stderr occurred is handled inside fetch; here we simply note miss
       if (ir && caching && fsUtils.isAvailable()) {
         try {
-          await fsUtils.writeFile(pathUtils.join(cacheDir, cacheKey), JSON.stringify(ir));
+          await fsUtils.writeFile(await pathUtils.join(cacheDir, cacheKey), JSON.stringify(ir));
         } catch {}
       }
     }
@@ -130,13 +130,13 @@ export async function generate(
 
     // Write file
     const baseName = moduleModel.name || 'module';
-    const outPath = pathUtils.join(outputDir, `${baseName}.generated.ts`);
+    const outPath = await pathUtils.join(outputDir, `${baseName}.generated.ts`);
     await fsUtils.writeFile(outPath, gen.typescript);
     written.push(outPath);
 
     // Optional .d.ts emission (header-only declarations mirroring exports)
     if (options.output?.declaration) {
-      const dtsPath = pathUtils.join(outputDir, `${baseName}.generated.d.ts`);
+      const dtsPath = await pathUtils.join(outputDir, `${baseName}.generated.d.ts`);
       const dts = renderDts(gen.typescript);
       await fsUtils.writeFile(dtsPath, dts);
       written.push(dtsPath);
@@ -144,7 +144,7 @@ export async function generate(
 
     // Optional source map emission (placeholder mapping for now)
     if (options.output?.sourceMap) {
-      const mapPath = pathUtils.join(outputDir, `${baseName}.generated.ts.map`);
+      const mapPath = await pathUtils.join(outputDir, `${baseName}.generated.ts.map`);
       const map = renderSourceMapPlaceholder(moduleModel.name);
       await fsUtils.writeFile(mapPath, map);
       written.push(mapPath);
@@ -162,9 +162,9 @@ export async function generate(
       );
       // Write JSON report
       try {
-        const reportsDir = pathUtils.join('.tywrap', 'reports');
+        const reportsDir = await pathUtils.join('.tywrap', 'reports');
         await fsUtils.writeFile(
-          pathUtils.join(reportsDir, `${baseName}.json`),
+          await pathUtils.join(reportsDir, `${baseName}.json`),
           JSON.stringify({
             module: baseName,
             unknowns: Object.fromEntries(entries),
@@ -197,7 +197,7 @@ async function fetchPythonIr(moduleName: string, pythonPath: string): Promise<un
     ]);
     if (result.code !== 0) {
       // Fallback to invoking local __main__.py
-      const localMain = pathUtils.join(process.cwd(), 'tywrap_ir', 'tywrap_ir', '__main__.py');
+      const localMain = await pathUtils.join(process.cwd(), 'tywrap_ir', 'tywrap_ir', '__main__.py');
       const fallback = await processUtils.exec(pythonPath, [
         localMain,
         '--module',

--- a/test/runtime_utils.test.ts
+++ b/test/runtime_utils.test.ts
@@ -8,8 +8,8 @@ describe('runtime utilities', () => {
     expect(second).toBe(first);
   });
 
-  it('normalizes joined paths', () => {
-    const joined = pathUtils.join('/foo', '.', 'bar');
+  it('normalizes joined paths', async () => {
+    const joined = await pathUtils.join('/foo', '.', 'bar');
     expect(joined.includes('/./')).toBe(false);
     expect(joined.endsWith('/foo/bar')).toBe(true);
   });

--- a/tools/matrix.ts
+++ b/tools/matrix.ts
@@ -26,8 +26,8 @@ const PACKAGES: readonly MatrixPackage[] = [
 
 async function ensureVenv(venvDir: string): Promise<string> {
   const python = 'python3';
-  const binDir = pathUtils.join(venvDir, 'bin');
-  const pythonBin = pathUtils.join(binDir, 'python');
+  const binDir = await pathUtils.join(venvDir, 'bin');
+  const pythonBin = await pathUtils.join(binDir, 'python');
   try {
     // Try a quick version check to see if venv exists
     const res = await processUtils.exec(pythonBin, ['-V']);
@@ -36,7 +36,7 @@ async function ensureVenv(venvDir: string): Promise<string> {
     }
   } catch {}
 
-  await fsUtils.writeFile(pathUtils.join(venvDir, '.placeholder'), '');
+  await fsUtils.writeFile(await pathUtils.join(venvDir, '.placeholder'), '');
   const create = await processUtils.exec(python, ['-m', 'venv', venvDir]);
   if (create.code !== 0) {
     throw new Error(`Failed to create venv: ${create.stderr}`);
@@ -70,7 +70,7 @@ async function generateForPackage(pkg: MatrixPackage, pythonBin: string): Promis
     runtime: { node: { pythonPath: pythonBin } },
   } as const;
 
-  const tmpConfigPath = pathUtils.join('.tywrap', `matrix.${name}.json`);
+  const tmpConfigPath = await pathUtils.join('.tywrap', `matrix.${name}.json`);
   const configText = JSON.stringify(config, null, 2);
   await fsUtils.writeFile(tmpConfigPath, configText);
 
@@ -87,7 +87,7 @@ async function generateForPackage(pkg: MatrixPackage, pythonBin: string): Promis
 }
 
 export async function run(): Promise<void> {
-  const venvDir = pathUtils.join('.tywrap', 'venv');
+  const venvDir = await pathUtils.join('.tywrap', 'venv');
   const pythonBin = await ensureVenv(venvDir);
   // Ensure tywrap_ir is available in the venv environment via PYTHONPATH set by processUtils
 


### PR DESCRIPTION
## Summary
- load `node:path` on demand and cache the module
- make path utilities async and update callers to await them

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b33bde09788323b3ddd00f7939e051