### PR TITLE
Freeze runtime detection results

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -237,15 +237,16 @@ const tsType = mapper.mapPythonType(pythonType, 'value');
 
 #### Runtime Detection
 ```typescript
-import { 
-  detectRuntime, 
-  isNodejs, 
-  isDeno, 
-  isBun, 
-  isBrowser 
+import {
+  detectRuntime,
+  isNodejs,
+  isDeno,
+  isBun,
+  isBrowser
 } from 'tywrap';
 
 const runtime = detectRuntime(); // 'node' | 'deno' | 'bun' | 'browser'
+// runtime is a frozen object and should be treated as read-only
 
 if (isNodejs()) {
   // Node.js specific code

--- a/src/utils/runtime.ts
+++ b/src/utils/runtime.ts
@@ -46,6 +46,7 @@ export function detectRuntime(): RuntimeInfo {
         fetch: true,
       },
     };
+    Object.freeze(runtimeCache);
     return runtimeCache;
   }
 
@@ -63,6 +64,7 @@ export function detectRuntime(): RuntimeInfo {
         fetch: true,
       },
     };
+    Object.freeze(runtimeCache);
     return runtimeCache;
   }
 
@@ -80,6 +82,7 @@ export function detectRuntime(): RuntimeInfo {
         fetch: typeof fetch !== 'undefined', // Available in Node.js 18+
       },
     };
+    Object.freeze(runtimeCache);
     return runtimeCache;
   }
 
@@ -103,6 +106,7 @@ export function detectRuntime(): RuntimeInfo {
         fetch: typeof fetch !== 'undefined',
       },
     };
+    Object.freeze(runtimeCache);
     return runtimeCache;
   }
 
@@ -117,6 +121,7 @@ export function detectRuntime(): RuntimeInfo {
       fetch: false,
     },
   };
+  Object.freeze(runtimeCache);
   return runtimeCache;
 }
 

--- a/test/runtime_utils.test.ts
+++ b/test/runtime_utils.test.ts
@@ -8,6 +8,11 @@ describe('runtime utilities', () => {
     expect(second).toBe(first);
   });
 
+  it('returns a frozen runtime info object', () => {
+    const runtime = detectRuntime();
+    expect(Object.isFrozen(runtime)).toBe(true);
+  });
+
   it('normalizes joined paths', () => {
     const joined = pathUtils.join('/foo', '.', 'bar');
     expect(joined.includes('/./')).toBe(false);


### PR DESCRIPTION
## Summary
- Freeze `detectRuntime` cache object to avoid external mutation
- Document the runtime info object as read-only
- Test that `detectRuntime` returns a frozen object

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b33fabf5f08323808876fb090482f8