### PR TITLE
fix: wrap single-line if with braces

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -38,7 +38,9 @@ const DEFAULT_CONFIG: TywrapConfig = {
 function merge<T>(base: T, override: Partial<T>): T {
   const result: Record<string, unknown> = { ...(base as Record<string, unknown>) };
   for (const [key, val] of Object.entries(override)) {
-    if (val === undefined) continue;
+    if (val === undefined) {
+      continue;
+    }
     const current = result[key];
     if (
       val &&


### PR DESCRIPTION
## Summary
- ensure merge helper uses braces to satisfy lint

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3d1cb92bc8323acc76ac8548c7b0c