### PR TITLE
Refactor cache to use fs/promises and add async tests

### DIFF
--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { IntelligentCache } from '../src/utils/cache.js';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+let cache: IntelligentCache;
+let dir: string;
+
+describe('IntelligentCache async operations', () => {
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'tywrap-cache-'));
+    cache = new IntelligentCache({ baseDir: dir, persistToDisk: true });
+    await cache.clear();
+  });
+
+  afterEach(async () => {
+    await cache.clear();
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('should set and get values asynchronously', async () => {
+    await cache.set('test-key', { value: 123 });
+    const result = await cache.get<{ value: number }>('test-key');
+    expect(result).toEqual({ value: 123 });
+  });
+
+  it('should handle I/O errors gracefully', async () => {
+    const fsModule = await import('fs');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const writeSpy = vi
+      .spyOn(fsModule.promises, 'writeFile')
+      .mockRejectedValue(new Error('disk full'));
+
+    await cache.set('fail-key', {});
+
+    expect(warnSpy).toHaveBeenCalled();
+
+    writeSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+});

--- a/test/performance-integration.test.skip.ts
+++ b/test/performance-integration.test.skip.ts
@@ -255,9 +255,9 @@ describePerformance('Performance Integration Tests', () => {
     await testSuite.teardown();
   }, 10000);
 
-  beforeEach(() => {
+  beforeEach(async () => {
     // Clear cache between tests for accurate measurements
-    globalCache.clear();
+    await globalCache.clear();
   });
 
   describe('IR Extraction Performance', () => {


### PR DESCRIPTION
## Summary
- refactor IntelligentCache to use `fs/promises` for all disk I/O with detailed error logging
- update cache API consumers for async `clear` and add new tests for async cache operations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3d7c4c5cc83238c61371a68d8c2fb