### PR TITLE
feat: add debug logging option

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,13 @@ export default defineConfig({
   development: {
     hotReload: true,
     validation: 'runtime'
-  }
+  },
+
+  debug: true
 });
 ```
+
+Enable `debug` to print cache and parallel processor diagnostics.
 
 ### Configuration Fields
 
@@ -140,6 +144,7 @@ export default defineConfig({
 - `runtime` – runtime paths and timeouts
 - `performance` – caching and batching controls
 - `development` – hot reloading and validation mode
+- `debug` – enable verbose debug logging
 
 ### Extension Hooks
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -29,6 +29,7 @@ const DEFAULT_CONFIG: TywrapConfig = {
   runtime: { node: { pythonPath: 'python3', timeout: 30000 } },
   performance: { caching: true, batching: false, compression: 'none' },
   development: { hotReload: false, sourceMap: false, validation: 'none' },
+  debug: false,
 };
 
 /**
@@ -68,6 +69,7 @@ function validateConfig(config: TywrapConfig): void {
     'runtime',
     'performance',
     'development',
+    'debug',
   ]);
   for (const key of Object.keys(config)) {
     if (!allowedTopLevel.has(key)) {
@@ -120,6 +122,10 @@ function validateConfig(config: TywrapConfig): void {
   const validValidation = ['runtime', 'compile', 'both', 'none'];
   if (!validValidation.includes(dev.validation)) {
     throw new Error(`development.validation must be one of ${validValidation.join(', ')}`);
+  }
+
+  if (typeof config.debug !== 'boolean') {
+    throw new Error('debug must be a boolean');
   }
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -237,6 +237,7 @@ export interface TywrapOptions {
   runtime: RuntimeConfig;
   performance: PerformanceConfig;
   development: DevelopmentConfig;
+  debug?: boolean;
 }
 
 export interface PythonModuleConfig {

--- a/src/tywrap.ts
+++ b/src/tywrap.ts
@@ -13,6 +13,8 @@ import type {
   PythonType,
 } from './types/index.js';
 import { fsUtils, pathUtils, processUtils, hashUtils } from './utils/runtime.js';
+import { globalCache } from './utils/cache.js';
+import { globalParallelProcessor } from './utils/parallel-processor.js';
 
 // Collect unknown typing constructs encountered during annotation parsing (per-generate run)
 let unknownTypeNamesCollector: Map<string, number> = new Map();
@@ -33,6 +35,9 @@ export interface TywrapInstance {
 export async function tywrap(options: Partial<TywrapOptions> = {}): Promise<TywrapInstance> {
   const mapper = new TypeMapper();
   const generator = new CodeGenerator();
+
+  globalCache.setDebug(options.debug ?? false);
+  globalParallelProcessor.setDebug(options.debug ?? false);
 
   return {
     mapper,

--- a/src/utils/parallel-processor.ts
+++ b/src/utils/parallel-processor.ts
@@ -50,6 +50,7 @@ export interface ParallelProcessorOptions {
   workerScript?: string; // Custom worker script path
   batchSize?: number; // Number of tasks to batch per worker
   loadBalancing?: 'round-robin' | 'least-loaded' | 'weighted';
+  debug?: boolean;
 }
 
 export class ParallelProcessor extends EventEmitter {
@@ -65,6 +66,7 @@ export class ParallelProcessor extends EventEmitter {
   private roundRobinIndex = 0;
   private options: Required<ParallelProcessorOptions>;
   private disposed = false;
+  private debug = false;
 
   constructor(options: ParallelProcessorOptions = {}) {
     super();
@@ -78,9 +80,14 @@ export class ParallelProcessor extends EventEmitter {
       workerScript: options.workerScript ?? __filename,
       batchSize: options.batchSize ?? 1,
       loadBalancing: options.loadBalancing ?? 'least-loaded',
+      debug: options.debug ?? false,
     };
 
-    console.log(`🚀 Parallel processor initialized with ${this.options.maxWorkers} workers`);
+    this.debug = this.options.debug;
+
+    if (this.debug) {
+      console.log(`🚀 Parallel processor initialized with ${this.options.maxWorkers} workers`);
+    }
   }
 
   /**
@@ -99,7 +106,9 @@ export class ParallelProcessor extends EventEmitter {
     // Start task processing
     this.processQueue();
 
-    console.log(`✅ Worker pool initialized with ${this.workers.size} workers`);
+    if (this.debug) {
+      console.log(`✅ Worker pool initialized with ${this.workers.size} workers`);
+    }
   }
 
   /**
@@ -112,7 +121,9 @@ export class ParallelProcessor extends EventEmitter {
     const chunkSize = options.chunkSize ?? Math.ceil(sources.length / this.options.maxWorkers);
     const chunks = this.chunkArray(sources, chunkSize);
     
-    console.log(`📊 Analyzing ${sources.length} modules in ${chunks.length} chunks`);
+    if (this.debug) {
+      console.log(`📊 Analyzing ${sources.length} modules in ${chunks.length} chunks`);
+    }
 
     const tasks: ParallelTask<AnalysisResult>[] = chunks.map((chunk, index) => ({
       id: `analyze_chunk_${index}`,
@@ -152,7 +163,9 @@ export class ParallelProcessor extends EventEmitter {
     const chunkSize = options.chunkSize ?? Math.ceil(modules.length / this.options.maxWorkers);
     const chunks = this.chunkArray(modules, chunkSize);
 
-    console.log(`🏗️  Generating ${modules.length} wrappers in ${chunks.length} chunks`);
+    if (this.debug) {
+      console.log(`🏗️  Generating ${modules.length} wrappers in ${chunks.length} chunks`);
+    }
 
     const tasks: ParallelTask<GeneratedCode>[] = chunks.map((chunk, index) => ({
       id: `generate_chunk_${index}`,
@@ -229,7 +242,9 @@ export class ParallelProcessor extends EventEmitter {
       const cacheKey = globalCache.generateKey('parallel_task', task.type, task.data);
       const cached = await globalCache.get<ParallelResult<T>>(cacheKey);
       if (cached) {
-        console.log(`🎯 Cache HIT for task ${task.id}`);
+        if (this.debug) {
+          console.log(`🎯 Cache HIT for task ${task.id}`);
+        }
         return cached;
       }
     }
@@ -398,7 +413,9 @@ export class ParallelProcessor extends EventEmitter {
       isActive: true,
     });
 
-    console.log(`👷 Spawned worker ${workerId}`);
+    if (this.debug) {
+      console.log(`👷 Spawned worker ${workerId}`);
+    }
     return worker;
   }
 
@@ -574,7 +591,9 @@ export class ParallelProcessor extends EventEmitter {
 
     this.disposed = true;
 
-    console.log('🛑 Disposing parallel processor...');
+    if (this.debug) {
+      console.log('🛑 Disposing parallel processor...');
+    }
 
     // Terminate all workers
     const terminationPromises = Array.from(this.workers.values()).map(worker => {
@@ -604,7 +623,13 @@ export class ParallelProcessor extends EventEmitter {
 
     this.removeAllListeners();
 
-    console.log('✅ Parallel processor disposed');
+    if (this.debug) {
+      console.log('✅ Parallel processor disposed');
+    }
+  }
+
+  setDebug(debug: boolean): void {
+    this.debug = debug;
   }
 }
 


### PR DESCRIPTION
## Summary
- add `debug` flag to configuration
- guard cache and parallel processor logs behind debug flag
- document debug usage in README

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3ded5eca88323ba57d15f2347e0ef