### PR TITLE
feat(cli): switch to yargs for argument parsing

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -484,16 +484,15 @@ try {
 ```bash
 # Generate wrappers
 tywrap generate [options]
-
-# Validate configuration  
-tywrap validate [options]
-
 # Show version
 tywrap --version
 
-# Show help
-tywrap --help
+# Show help for commands
+tywrap generate --help
 ```
+
+The CLI uses argument validation and will exit with an error on unknown
+commands or options.
 
 ### Programmatic CLI
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -80,6 +80,8 @@ tywrap generate --config tywrap.config.json
 node -e "import('tywrap').then(tw => tw.generate(require('./tywrap.config.json')))"
 ```
 
+Run `tywrap generate --help` to see all available options and defaults.
+
 ## Usage
 
 After generation, import and use your Python library with full TypeScript support:

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "tree-sitter": "^0.21.0",
         "tree-sitter-python": "^0.21.0",
         "typescript": "^5.6.2",
-        "web-tree-sitter": "^0.21.0"
+        "web-tree-sitter": "^0.21.0",
+        "yargs": "^17.7.2"
       },
       "bin": {
         "tywrap": "dist/cli.js"
@@ -25,6 +26,7 @@
       "devDependencies": {
         "@types/bun": "^1.2.19",
         "@types/node": "^22.5.4",
+        "@types/yargs": "^17.0.33",
         "@typescript-eslint/eslint-plugin": "^8.5.0",
         "@typescript-eslint/parser": "^8.5.0",
         "eslint": "^9.10.0",
@@ -461,6 +463,34 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.46.2.tgz",
+      "integrity": "sha512-Zj3Hl6sN34xJtMv7Anwb5Gu01yujyE/cLBDB2gnHTAHaWS1Z38L7kuSG+oAh0giZMqG060f/YBStXtMH6FvPMA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.46.2.tgz",
+      "integrity": "sha512-nTeCWY83kN64oQ5MGz3CgtPx8NSOhC5lWtsjTs+8JAJNLcP3QbLCtDDgUKQc/Ro/frpMq4SHUaHN6AMltcEoLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.46.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.46.2.tgz",
@@ -473,6 +503,230 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.46.2.tgz",
+      "integrity": "sha512-SSj8TlYV5nJixSsm/y3QXfhspSiLYP11zpfwp6G/YDXctf3Xkdnk4woJIF5VQe0of2OjzTt8EsxnJDCdHd2xMA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.46.2.tgz",
+      "integrity": "sha512-ZyrsG4TIT9xnOlLsSSi9w/X29tCbK1yegE49RYm3tu3wF1L/B6LVMqnEWyDB26d9Ecx9zrmXCiPmIabVuLmNSg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.46.2.tgz",
+      "integrity": "sha512-pCgHFoOECwVCJ5GFq8+gR8SBKnMO+xe5UEqbemxBpCKYQddRQMgomv1104RnLSg7nNvgKy05sLsY51+OVRyiVw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.46.2.tgz",
+      "integrity": "sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.46.2.tgz",
+      "integrity": "sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.46.2.tgz",
+      "integrity": "sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.46.2.tgz",
+      "integrity": "sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.46.2.tgz",
+      "integrity": "sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.46.2.tgz",
+      "integrity": "sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.46.2.tgz",
+      "integrity": "sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.46.2.tgz",
+      "integrity": "sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.46.2.tgz",
+      "integrity": "sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.46.2.tgz",
+      "integrity": "sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.46.2.tgz",
+      "integrity": "sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.46.2.tgz",
+      "integrity": "sha512-gBgaUDESVzMgWZhcyjfs9QFK16D8K6QZpwAaVNJxYDLHWayOta4ZMjGm/vsAEy3hvlS2GosVFlBlP9/Wb85DqQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.46.2.tgz",
+      "integrity": "sha512-CvUo2ixeIQGtF6WvuB87XWqPQkoFAFqW+HUo/WzHwuHDvIwZCtjdWXoYCcr06iKGydiqTclC4jU/TNObC/xKZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@rtsao/scc": {
@@ -575,6 +829,23 @@
       "dependencies": {
         "csstype": "^3.0.2"
       }
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.33",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.39.0",
@@ -1008,7 +1279,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1018,7 +1288,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -1400,11 +1669,24 @@
         "node": ">= 16"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -1417,7 +1699,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/commondir": {
@@ -1674,7 +1955,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/error-ex": {
@@ -1880,6 +2160,15 @@
         "@esbuild/win32-arm64": "0.21.5",
         "@esbuild/win32-ia32": "0.21.5",
         "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2729,6 +3018,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -3271,7 +3569,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4749,6 +5046,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -4858,6 +5164,20 @@
         "rollup": ">=1.26.3",
         "typescript": ">=2.4.0"
       }
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.46.2.tgz",
+      "integrity": "sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -5211,7 +5531,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -5285,7 +5604,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -6069,6 +6387,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/ws": {
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
@@ -6091,12 +6426,39 @@
         }
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yargs-parser": {
       "version": "20.2.9",
@@ -6106,6 +6468,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yargs/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -73,11 +73,13 @@
     "tree-sitter": "^0.21.0",
     "tree-sitter-python": "^0.21.0",
     "typescript": "^5.6.2",
-    "web-tree-sitter": "^0.21.0"
+    "web-tree-sitter": "^0.21.0",
+    "yargs": "^17.7.2"
   },
   "devDependencies": {
     "@types/bun": "^1.2.19",
     "@types/node": "^22.5.4",
+    "@types/yargs": "^17.0.33",
     "@typescript-eslint/eslint-plugin": "^8.5.0",
     "@typescript-eslint/parser": "^8.5.0",
     "eslint": "^9.10.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,139 +1,146 @@
 #!/usr/bin/env node
+import yargs, { type Argv, type ArgumentsCamelCase } from 'yargs';
+import { hideBin } from 'yargs/helpers';
 import type { TywrapOptions } from './types/index.js';
-import { generate } from './tywrap.js';
 
 async function main(): Promise<void> {
-  const args = process.argv.slice(2);
-  // Prefer JSON config by default in dist builds to avoid TS loader requirements
-  let configPath = './tywrap.config.json';
-  let useCache: boolean | undefined;
-  let modulesList: string | undefined;
-  let pythonPath: string | undefined;
-  let outputDir: string | undefined;
-  let declarationFlag: boolean | undefined;
-  let sourceMapFlag: boolean | undefined;
-  let failOnWarn = false;
-  // Parse args without index-based access to satisfy security rules
-  const queue = [...args];
-  while (queue.length > 0) {
-    const a = queue.shift() as string;
-    if (a === '-c' || a === '--config') {
-      const val = queue.shift();
-      if (typeof val === 'string') {
-        configPath = val;
-      }
-    } else if (a === '--use-cache') {
-      useCache = true;
-    } else if (a === '--no-cache') {
-      useCache = false;
-    } else if (a === '--modules') {
-      const val = queue.shift();
-      if (typeof val === 'string') {
-        modulesList = val;
-      }
-    } else if (a === '--python') {
-      const val = queue.shift();
-      if (typeof val === 'string') {
-        pythonPath = val;
-      }
-    } else if (a === '--output-dir') {
-      const val = queue.shift();
-      if (typeof val === 'string') {
-        outputDir = val;
-      }
-    } else if (a === '--declaration') {
-      declarationFlag = true;
-    } else if (a === '--no-declaration') {
-      declarationFlag = false;
-    } else if (a === '--source-map') {
-      sourceMapFlag = true;
-    } else if (a === '--no-source-map') {
-      sourceMapFlag = false;
-    } else if (a === '--fail-on-warn') {
-      failOnWarn = true;
-    }
-  }
+  await yargs(hideBin(process.argv))
+    .command(
+      'generate',
+      'Generate TypeScript wrappers',
+      (y: Argv) =>
+        y
+          .option('config', {
+            alias: 'c',
+            type: 'string',
+            default: './tywrap.config.json',
+            describe: 'Path to config file',
+          })
+          .option('modules', {
+            type: 'string',
+            describe: 'Comma-separated list of Python modules to wrap',
+          })
+          .option('python', {
+            type: 'string',
+            describe: 'Path to Python executable',
+          })
+          .option('output-dir', {
+            type: 'string',
+            describe: 'Directory for generated wrappers',
+          })
+          .option('declaration', {
+            type: 'boolean',
+            describe: 'Emit TypeScript declaration files',
+          })
+          .option('source-map', {
+            type: 'boolean',
+            describe: 'Emit source maps for generated files',
+          })
+          .option('use-cache', {
+            alias: 'cache',
+            type: 'boolean',
+            describe: 'Enable on-disk caching (use --no-cache to disable)',
+          })
+          .option('fail-on-warn', {
+            type: 'boolean',
+            default: false,
+            describe: 'Exit with code 2 if generation emits warnings',
+          })
+          .strict(),
+      async (
+        argv: ArgumentsCamelCase<{
+          config: string;
+          modules?: string;
+          python?: string;
+          outputDir?: string;
+          declaration?: boolean;
+          sourceMap?: boolean;
+          useCache?: boolean;
+          failOnWarn: boolean;
+        }>
+      ) => {
+        const configPath = argv.config;
+        const modulesList = argv.modules;
+        const pythonPath = argv.python;
+        const outputDir = argv.outputDir;
+        const declarationFlag = argv.declaration;
+        const sourceMapFlag = argv.sourceMap;
+        const useCache = argv.useCache;
+        const failOnWarn = argv.failOnWarn;
 
-  if (args[0] !== 'generate') {
-    console.error(
-      'Usage: tywrap generate [--config <path>] [--modules a,b,c] [--python <path>] [--output-dir <dir>] [--use-cache|--no-cache] [--fail-on-warn]'
-    );
-    process.exit(1);
-  }
+        const { generate } = await import('./tywrap.js');
 
-  try {
-    // Support JS/TS/JSON configs via dynamic import; Node with ts-node/transpiled preferred for TS
-    let options: Partial<TywrapOptions>;
-    if (configPath.endsWith('.json')) {
-      const { readFile } = await import('fs/promises');
-      const txt = await readFile(configPath, 'utf-8');
-      options = JSON.parse(txt) as Partial<TywrapOptions>;
-    } else {
-      const mod = await import(configPath);
-      const loaded = (mod as Record<string, unknown>).default ?? mod;
-      options = (loaded ?? {}) as Partial<TywrapOptions>;
-    }
+        try {
+          // Support JS/TS/JSON configs via dynamic import; Node with ts-node/transpiled preferred for TS
+          let options: Partial<TywrapOptions>;
+          if (configPath.endsWith('.json')) {
+            const { readFile } = await import('fs/promises');
+            const txt = await readFile(configPath, 'utf-8');
+            options = JSON.parse(txt) as Partial<TywrapOptions>;
+          } else {
+            const mod = await import(configPath);
+            const loaded = (mod as Record<string, unknown>).default ?? mod;
+            options = (loaded ?? {}) as Partial<TywrapOptions>;
+          }
 
-    // Override options via flags
-    if (modulesList) {
-      const names = modulesList
-        .split(',')
-        .map(s => s.trim())
-        .filter(Boolean);
-      options.pythonModules = Object.fromEntries(
-        names.map(n => [n, { runtime: 'node', typeHints: 'strict' }])
-      );
-    }
-    if (outputDir) {
-      options.output = {
-        ...(options.output ?? {}),
-        dir: outputDir,
-        format: options.output?.format ?? 'esm',
-        declaration: declarationFlag ?? options.output?.declaration ?? false,
-        sourceMap: sourceMapFlag ?? options.output?.sourceMap ?? false,
-      };
-    }
-    if (typeof declarationFlag === 'boolean' || typeof sourceMapFlag === 'boolean') {
-      options.output = {
-        ...(options.output ?? {
-          dir: './generated',
-          format: 'esm',
-          declaration: false,
-          sourceMap: false,
-        }),
-        declaration: declarationFlag ?? options.output?.declaration ?? false,
-        sourceMap: sourceMapFlag ?? options.output?.sourceMap ?? false,
-      };
-    }
-    if (typeof useCache === 'boolean') {
-      options.performance = {
-        ...(options.performance ?? {}),
-        caching: useCache,
-        batching: options.performance?.batching ?? false,
-        compression: options.performance?.compression ?? 'none',
-      };
-    }
-    if (pythonPath) {
-      options.runtime = {
-        ...(options.runtime ?? {}),
-        node: { ...(options.runtime?.node ?? {}), pythonPath },
-      };
-    }
+          // Override options via flags
+          if (modulesList) {
+            const names = modulesList
+              .split(',')
+              .map(s => s.trim())
+              .filter(Boolean);
+            options.pythonModules = Object.fromEntries(
+              names.map(n => [n, { runtime: 'node', typeHints: 'strict' }])
+            );
+          }
+          if (outputDir || typeof declarationFlag === 'boolean' || typeof sourceMapFlag === 'boolean') {
+            options.output = {
+              ...(options.output ?? {
+                dir: './generated',
+                format: 'esm',
+                declaration: false,
+                sourceMap: false,
+              }),
+              ...(outputDir ? { dir: outputDir } : {}),
+              declaration:
+                declarationFlag ?? options.output?.declaration ?? false,
+              sourceMap: sourceMapFlag ?? options.output?.sourceMap ?? false,
+            };
+          }
+          if (typeof useCache === 'boolean') {
+            options.performance = {
+              ...(options.performance ?? {}),
+              caching: useCache,
+              batching: options.performance?.batching ?? false,
+              compression: options.performance?.compression ?? 'none',
+            };
+          }
+          if (pythonPath) {
+            options.runtime = {
+              ...(options.runtime ?? {}),
+              node: { ...(options.runtime?.node ?? {}), pythonPath },
+            };
+          }
 
-    const res = await generate(options);
-    // eslint-disable-next-line no-console
-    console.log(`Generated: ${res.written.join(', ')}`);
-    if (failOnWarn && res.warnings.length > 0) {
-      console.error(
-        `Warnings encountered (count ${res.warnings.length}). Failing due to --fail-on-warn.`
-      );
-      process.exit(2);
-    }
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    console.error('Generation failed:', message);
-    process.exit(1);
-  }
+          const res = await generate(options);
+          process.stdout.write(`Generated: ${res.written.join(', ')}\n`);
+          if (failOnWarn && res.warnings.length > 0) {
+            console.error(
+              `Warnings encountered (count ${res.warnings.length}). Failing due to --fail-on-warn.`
+            );
+            process.exit(2);
+          }
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : String(err);
+          console.error('Generation failed:', message);
+          process.exit(1);
+        }
+      }
+    )
+    .demandCommand(1, 'Please specify a command')
+    .strict()
+    .help().argv;
 }
 
 main();
+

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const CLI_PATH = join(__dirname, '../dist/cli.js');
+
+describe('CLI', () => {
+  it('shows help when no command is provided', () => {
+    const res = spawnSync('node', [CLI_PATH], { encoding: 'utf-8' });
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain('Commands:');
+  });
+
+  it('errors on unknown options', () => {
+    const res = spawnSync('node', [CLI_PATH, 'generate', '--unknown'], {
+      encoding: 'utf-8',
+    });
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain('Unknown argument: unknown');
+  });
+});
+


### PR DESCRIPTION
## Summary
- refactor CLI to use yargs for command parsing, defaults and help text
- document new CLI usage and validation behavior
- add tests covering CLI help and unknown option handling
- remove console.log lint suppression by writing directly to stdout

## Testing
- `npm test`
- `npm run lint` (warnings only)


------
https://chatgpt.com/codex/tasks/task_e_68b3e09db0e88323b4af4ac0f8d67e8d