### PR TITLE
feat: use AST for bundle analysis

### DIFF
--- a/src/utils/bundle-optimizer.ts
+++ b/src/utils/bundle-optimizer.ts
@@ -242,11 +242,10 @@ export class BundleOptimizer {
         }
       } else if (
         ts.isCallExpression(node) &&
-        node.expression.kind === ts.SyntaxKind.ImportKeyword &&
-        node.arguments.length > 0
+        node.expression.kind === ts.SyntaxKind.ImportKeyword
       ) {
         const arg = node.arguments[0];
-        if (ts.isStringLiteral(arg)) {
+        if (arg && ts.isStringLiteral(arg)) {
           imports.add(arg.text);
         }
       }

--- a/test/performance-integration.test.ts
+++ b/test/performance-integration.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { BundleOptimizer } from '../src/utils/bundle-optimizer.js';
+
+describe('BundleOptimizer AST extraction', () => {
+  const optimizer = new BundleOptimizer();
+
+  const code = `
+import defaultExport, {foo as bar, type Baz, qux} from './mod1';
+import * as All from "./mod2";
+const dynamic = await import('./mod3');
+import type { TypesOnly } from './types';
+import { something } from './other'; // types
+
+export { bar as renamed } from './mod1';
+export * from './mod2';
+export default function defaultFunction() {}
+export class MyClass {}
+const local1 = 1;
+export { local1 as alias1 };
+__bridge.call('something');
+decodeValue();
+`;
+
+  it('extracts complex imports', () => {
+    const imports = (optimizer as any).extractImports(code);
+    expect(imports).toEqual(expect.arrayContaining([
+      'defaultExport',
+      'foo',
+      'Baz',
+      'qux',
+      'All',
+      'TypesOnly',
+      'something',
+      './mod1',
+      './mod2',
+      './mod3',
+      './types',
+      './other'
+    ]));
+  });
+
+  it('extracts complex exports', () => {
+    const exports = (optimizer as any).extractExports(code);
+    expect(exports).toEqual(expect.arrayContaining([
+      'defaultFunction',
+      'MyClass',
+      'bar',
+      'local1',
+      '*'
+    ]));
+  });
+
+  it('extracts dependencies', () => {
+    const deps = (optimizer as any).extractDependencies(code);
+    expect(deps).toEqual(expect.arrayContaining([
+      'runtime-bridge',
+      'codec',
+      './types',
+      './other'
+    ]));
+  });
+});


### PR DESCRIPTION
## Summary
- parse TypeScript with the compiler API for bundle analysis
- replace regex import/export/dependency detection with AST traversal
- add tests for complex import and export scenarios

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b46699ec488323a8abb5c49b7dfad0