### PR TITLE
fix: guard dynamic import argument

### DIFF
--- a/src/utils/bundle-optimizer.ts
+++ b/src/utils/bundle-optimizer.ts
@@ -242,11 +242,10 @@ export class BundleOptimizer {
         }
       } else if (
         ts.isCallExpression(node) &&
-        node.expression.kind === ts.SyntaxKind.ImportKeyword &&
-        node.arguments.length > 0
+        node.expression.kind === ts.SyntaxKind.ImportKeyword
       ) {
         const arg = node.arguments[0];
-        if (ts.isStringLiteral(arg)) {
+        if (arg && ts.isStringLiteral(arg)) {
           imports.add(arg.text);
         }
       }


### PR DESCRIPTION
## Summary
- ensure dynamic `import()` verifies its first argument before inspecting it

## Testing
- `npm run build`
- `npm test`
- `npm run test:types`


------
https://chatgpt.com/codex/tasks/task_e_68b7da683e948323aee776bd107d8122