### PR TITLE
DevEx: tywrap generate --check

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,14 @@ TypeScript wrapper for Python libraries with full type safety.
 
 ```bash
 npm install tywrap
-npx tywrap init      # Create config
+npx tywrap init      # Create config (and package.json scripts if present)
 npx tywrap generate  # Generate wrappers
+```
+
+For CI (or to verify a dependency upgrade didn’t change the generated surface):
+
+```bash
+npx tywrap generate --check
 ```
 
 ```typescript

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -260,7 +260,9 @@ async function demo() {
 ```
 
 ### Build Integration
-Run `tywrap generate` as part of your build pipeline until official integrations land.
+Run `tywrap generate --check` in CI to ensure generated wrappers are committed and up to date. After upgrading Python dependencies, run `tywrap generate` to refresh the generated surface.
+
+If you ran `tywrap init` in a Node project, it will also add `tywrap:generate` and `tywrap:check` scripts to `package.json` (disable with `--no-scripts`).
 
 ## Performance Tips
 


### PR DESCRIPTION
## What
- Add `tywrap generate --check` to verify generated wrappers are up to date without writing files (CI-friendly).
- Add optional package.json script wiring in `tywrap init` (`tywrap:generate`, `tywrap:check`; disable with `--no-scripts`).

## Behavior
- Check mode avoids writing output files, `.tywrap/cache`, and `.tywrap/reports`.
- Exit code `3` when wrappers are out of date (`2` remains reserved for `--fail-on-warn`).

## Tests
- `npm run check:all`