### PR TITLE
fix(codec): await nested Arrow decode in torch

### DIFF
--- a/src/utils/codec.ts
+++ b/src/utils/codec.ts
@@ -151,7 +151,22 @@ async function tryDecodeArrowTable(bytes: Uint8Array): Promise<ArrowTable | Uint
   }
 }
 
-function decodeEnvelope<T>(value: unknown, decodeArrow: (bytes: Uint8Array) => T): T | unknown {
+type MaybePromise<T> = T | Promise<T>;
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'then' in value &&
+    typeof (value as { then?: unknown }).then === 'function'
+  );
+}
+
+function decodeEnvelopeCore<T>(
+  value: unknown,
+  decodeArrow: (bytes: Uint8Array) => MaybePromise<T>,
+  recurse: (value: unknown) => MaybePromise<T | unknown>
+): MaybePromise<T | unknown> {
   if (!isObject(value)) {
     return value;
   }
@@ -226,7 +241,15 @@ function decodeEnvelope<T>(value: unknown, decodeArrow: (bytes: Uint8Array) => T
       device?: string;
     };
     if ('value' in (torchValue as object)) {
-      const decoded = decodeEnvelope(torchValue.value, decodeArrow);
+      const decoded = recurse(torchValue.value);
+      if (isPromiseLike(decoded)) {
+        return decoded.then(data => ({
+          data,
+          shape: torchValue.shape,
+          dtype: torchValue.dtype,
+          device: torchValue.device,
+        })) as Promise<T | unknown>;
+      }
       return {
         data: decoded,
         shape: torchValue.shape,
@@ -258,115 +281,23 @@ function decodeEnvelope<T>(value: unknown, decodeArrow: (bytes: Uint8Array) => T
   return value as unknown;
 }
 
+function decodeEnvelope<T>(value: unknown, decodeArrow: (bytes: Uint8Array) => T): T | unknown {
+  const recurse: (value: unknown) => MaybePromise<T | unknown> = v =>
+    decodeEnvelopeCore(v, decodeArrow, recurse);
+  const decoded = decodeEnvelopeCore(value, decodeArrow, recurse);
+  if (isPromiseLike(decoded)) {
+    throw new Error('Unexpected Promise return from decodeValue; use decodeValueAsync instead.');
+  }
+  return decoded;
+}
+
 async function decodeEnvelopeAsync<T>(
   value: unknown,
   decodeArrow: (bytes: Uint8Array) => Promise<T>
 ): Promise<T | unknown> {
-  // Keep an async version so nested Arrow decoding (e.g. torch.tensor -> ndarray) can be awaited.
-  if (!isObject(value)) {
-    return value;
-  }
-  const marker = (value as { __tywrap__?: unknown }).__tywrap__;
-  if (
-    (marker === 'dataframe' || marker === 'series') &&
-    (value as { encoding?: unknown }).encoding === 'arrow' &&
-    typeof (value as { b64?: unknown }).b64 === 'string'
-  ) {
-    const bytes = fromBase64(String((value as { b64: string }).b64));
-    return await decodeArrow(bytes);
-  }
-  if (
-    marker === 'dataframe' &&
-    (value as { encoding?: unknown }).encoding === 'json' &&
-    'data' in (value as object)
-  ) {
-    return (value as { data: unknown }).data;
-  }
-  if (
-    marker === 'series' &&
-    (value as { encoding?: unknown }).encoding === 'json' &&
-    'data' in (value as object)
-  ) {
-    return (value as { data: unknown }).data;
-  }
-  if (marker === 'ndarray') {
-    if (
-      (value as { encoding?: unknown }).encoding === 'arrow' &&
-      typeof (value as { b64?: unknown }).b64 === 'string'
-    ) {
-      const bytes = fromBase64(String((value as { b64: string }).b64));
-      return await decodeArrow(bytes);
-    }
-    if ((value as { encoding?: unknown }).encoding === 'json' && 'data' in (value as object)) {
-      return (value as { data: unknown }).data;
-    }
-  }
-  if (
-    marker === 'scipy.sparse' &&
-    (value as { encoding?: unknown }).encoding === 'json' &&
-    typeof (value as { format?: unknown }).format === 'string' &&
-    Array.isArray((value as { shape?: unknown }).shape) &&
-    Array.isArray((value as { data?: unknown }).data)
-  ) {
-    const sparse = value as {
-      format: 'csr' | 'csc' | 'coo';
-      shape: readonly number[];
-      data: readonly unknown[];
-      indices?: readonly number[];
-      indptr?: readonly number[];
-      row?: readonly number[];
-      col?: readonly number[];
-      dtype?: string;
-    };
-    return {
-      format: sparse.format,
-      shape: sparse.shape,
-      data: sparse.data,
-      indices: sparse.indices,
-      indptr: sparse.indptr,
-      row: sparse.row,
-      col: sparse.col,
-      dtype: sparse.dtype,
-    } satisfies SparseMatrix;
-  }
-  if (marker === 'torch.tensor' && (value as { encoding?: unknown }).encoding === 'ndarray') {
-    const torchValue = value as {
-      value?: unknown;
-      shape?: readonly number[];
-      dtype?: string;
-      device?: string;
-    };
-    if ('value' in (torchValue as object)) {
-      const decoded = await decodeEnvelopeAsync(torchValue.value, decodeArrow);
-      return {
-        data: decoded,
-        shape: torchValue.shape,
-        dtype: torchValue.dtype,
-        device: torchValue.device,
-      } satisfies TorchTensor;
-    }
-  }
-  if (
-    marker === 'sklearn.estimator' &&
-    (value as { encoding?: unknown }).encoding === 'json' &&
-    typeof (value as { className?: unknown }).className === 'string' &&
-    typeof (value as { module?: unknown }).module === 'string' &&
-    isObject((value as { params?: unknown }).params)
-  ) {
-    const estimator = value as {
-      className: string;
-      module: string;
-      version?: string;
-      params: Record<string, unknown>;
-    };
-    return {
-      className: estimator.className,
-      module: estimator.module,
-      version: estimator.version,
-      params: estimator.params,
-    } satisfies SklearnEstimator;
-  }
-  return value as unknown;
+  const recurse: (value: unknown) => MaybePromise<T | unknown> = v =>
+    decodeEnvelopeCore(v, decodeArrow, recurse);
+  return await decodeEnvelopeCore(value, decodeArrow, recurse);
 }
 
 /**

--- a/test/runtime_codec.test.ts
+++ b/test/runtime_codec.test.ts
@@ -410,6 +410,8 @@ describe('Cross-Runtime Data Transfer Codec', () => {
       };
 
       const result = await decodeValueAsync(envelope);
+      // Explicitly verify data is resolved, not a Promise (issue #21)
+      expect((result as any).data).not.toBeInstanceOf(Promise);
       expect(result).toEqual({
         data: expect.any(Uint8Array),
         shape: [3],


### PR DESCRIPTION
Fixes #21

## What
- Ensure `decodeValueAsync` awaits nested envelope decodes when decoding `torch.tensor` values (so `TorchTensor.data` is never a Promise).

## Tests
- Added a regression test for a torch tensor containing an Arrow-encoded ndarray.