### PR TITLE
chore(ci): add required aggregate check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,3 +244,27 @@ jobs:
           pip install -e .
       - name: Run Bun tests
         run: bun run test:bun
+
+  required:
+    if: ${{ always() && github.event_name != 'schedule' }}
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - test
+      - python-suite-core
+      - python-suite-data
+      - living-app
+      - os
+      - bun
+    steps:
+      - name: Check required jobs
+        run: |
+          fail=0
+          if [ "${{ needs.lint.result }}" != "success" ]; then echo "::error::lint: ${{ needs.lint.result }}"; fail=1; fi
+          if [ "${{ needs.test.result }}" != "success" ]; then echo "::error::test: ${{ needs.test.result }}"; fail=1; fi
+          if [ "${{ needs.python-suite-core.result }}" != "success" ]; then echo "::error::python-suite-core: ${{ needs.python-suite-core.result }}"; fail=1; fi
+          if [ "${{ needs.python-suite-data.result }}" != "success" ]; then echo "::error::python-suite-data: ${{ needs.python-suite-data.result }}"; fail=1; fi
+          if [ "${{ needs.living-app.result }}" != "success" ]; then echo "::error::living-app: ${{ needs.living-app.result }}"; fail=1; fi
+          if [ "${{ needs.os.result }}" != "success" ]; then echo "::error::os: ${{ needs.os.result }}"; fail=1; fi
+          if [ "${{ needs.bun.result }}" != "success" ]; then echo "::error::bun: ${{ needs.bun.result }}"; fail=1; fi
+          if [ "$fail" -ne 0 ]; then exit 1; fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,5 +15,6 @@ Thanks for your interest in contributing!
 - Pull Requests:
   - Include tests and type definitions where applicable
   - Ensure `npm run check:all` passes
+  - Wait for CI to be green (including `CI/required`) and for CodeRabbit to complete; resolve all review threads
 
 By contributing, you agree to license your contributions under the project’s MIT License.


### PR DESCRIPTION
Adds a single CI job (CI/required) that depends on all PR-critical jobs and fails if any of them fail. This lets us require one check in branch protection so auto-merge cannot merge while checks are still running.