### PR TITLE
fix(ci): add NPM_TOKEN for npm publish authentication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -171,11 +171,12 @@ jobs:
         if: inputs.dry_run == true
         run: npm publish --dry-run
 
-      # With OIDC trusted publishing, no NPM_TOKEN needed
-      # Provenance is automatic with trusted publishing
+      # Use NPM_TOKEN for authentication with provenance for supply chain security
       - name: Publish to npm
         if: inputs.dry_run != true
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
         if: inputs.dry_run != true && startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
## Summary
- Adds `NODE_AUTH_TOKEN` environment variable using `NPM_TOKEN` secret for npm publish step
- Fixes E404 error when publishing to npm registry
- Keeps `--provenance` flag for supply chain security

## Root Cause
The OIDC trusted publishing alone doesn't work when `actions/setup-node@v4` is configured with `registry-url`. The action creates an `.npmrc` that expects `NODE_AUTH_TOKEN` to be set, but we weren't providing it.

## Test plan
- [ ] CI tests pass
- [ ] Re-run publish workflow for v0.1.2 tag after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)