### PR TITLE
feat(pypi): add tywrap-ir PyPI publishing

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Test Python API
         run: |
-          python -c "from tywrap_ir import extract_module_ir, IR_VERSION; print(f'IR_VERSION: {IR_VERSION}')"
+          python -c "from tywrap_ir import extract_module_ir, IR_VERSION, __version__; print(f'IR_VERSION: {IR_VERSION}, __version__: {__version__}')"
 
   build:
     name: Build Package

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,141 @@
+name: Publish tywrap-ir to PyPI
+
+on:
+  push:
+    tags:
+      - 'tywrap-ir-v*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (skip actual publish)'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  validate:
+    name: Validate Release
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/tywrap-ir-v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/tywrap-ir-v}"
+          else
+            VERSION=$(grep 'version = ' tywrap_ir/pyproject.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Publishing tywrap-ir version: $VERSION"
+
+      - name: Validate version format
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
+            echo "Invalid version format: $VERSION"
+            exit 1
+          fi
+
+      - name: Check version matches pyproject.toml
+        if: startsWith(github.ref, 'refs/tags/tywrap-ir-v')
+        run: |
+          TAG_VERSION="${{ steps.version.outputs.version }}"
+          PKG_VERSION=$(grep 'version = ' tywrap_ir/pyproject.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          if [[ "$TAG_VERSION" != "$PKG_VERSION" ]]; then
+            echo "Tag version ($TAG_VERSION) does not match pyproject.toml ($PKG_VERSION)"
+            exit 1
+          fi
+
+  test:
+    name: Test
+    needs: validate
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install tywrap_ir
+        run: |
+          cd tywrap_ir
+          pip install -e .
+
+      - name: Test CLI
+        run: |
+          tywrap-ir --module math --output /tmp/math_ir.json
+          python -c "import json; data = json.load(open('/tmp/math_ir.json')); print(f'Extracted {len(data.get(\"functions\", []))} functions from math module')"
+
+      - name: Test Python API
+        run: |
+          python -c "from tywrap_ir import extract_module_ir, IR_VERSION; print(f'IR_VERSION: {IR_VERSION}')"
+
+  build:
+    name: Build Package
+    needs: [validate, test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install build tools
+        run: pip install build twine
+
+      - name: Build package
+        run: |
+          cd tywrap_ir
+          python -m build
+
+      - name: Check package
+        run: |
+          cd tywrap_ir
+          twine check dist/*
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: tywrap_ir/dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: [validate, test, build]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish (dry run)
+        if: inputs.dry_run == true
+        run: |
+          echo "Dry run - would publish:"
+          ls -la dist/
+
+      - name: Publish to PyPI
+        if: inputs.dry_run != true
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ TypeScript wrapper for Python libraries with full type safety.
 
 - Node.js 20+ (or Bun 1.1+ / Deno 1.46+)
 - Python 3.10+ with `tywrap-ir`:
+
   ```bash
   pip install tywrap-ir
   ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # tywrap
 
 [![npm version](https://img.shields.io/npm/v/tywrap.svg)](https://www.npmjs.com/package/tywrap)
+[![PyPI version](https://img.shields.io/pypi/v/tywrap-ir.svg)](https://pypi.org/project/tywrap-ir/)
 [![CI](https://github.com/bbopen/tywrap/actions/workflows/ci.yml/badge.svg)](https://github.com/bbopen/tywrap/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -18,14 +19,18 @@ TypeScript wrapper for Python libraries with full type safety.
 ## Requirements
 
 - Node.js 20+ (or Bun 1.1+ / Deno 1.46+)
-- Python 3.10+
+- Python 3.10+ with `tywrap-ir`:
+  ```bash
+  pip install tywrap-ir
+  ```
 
 ## Quick Start
 
 ```bash
 npm install tywrap
-npx tywrap init      # Create config (and package.json scripts if present)
-npx tywrap generate  # Generate wrappers
+pip install tywrap-ir  # Python component for code generation
+npx tywrap init        # Create config (and package.json scripts if present)
+npx tywrap generate    # Generate wrappers
 ```
 
 For CI (or to verify a dependency upgrade didn’t change the generated surface):
@@ -149,4 +154,5 @@ MIT © [tywrap contributors](LICENSE)
 
 - [GitHub](https://github.com/bbopen/tywrap)
 - [npm](https://www.npmjs.com/package/tywrap)
+- [PyPI](https://pypi.org/project/tywrap-ir/)
 - [Issues](https://github.com/bbopen/tywrap/issues)

--- a/tywrap_ir/README.md
+++ b/tywrap_ir/README.md
@@ -1,11 +1,45 @@
-# tywrap_ir
+# tywrap-ir
 
-Python IR extractor for tywrap. Emits versioned JSON IR for Python modules using inspect/typing/importlib.
+[![PyPI version](https://img.shields.io/pypi/v/tywrap-ir.svg)](https://pypi.org/project/tywrap-ir/)
+[![Python versions](https://img.shields.io/pypi/pyversions/tywrap-ir.svg)](https://pypi.org/project/tywrap-ir/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+Python IR extractor for [tywrap](https://github.com/bbopen/tywrap). Emits versioned JSON IR for Python modules using inspect/typing/importlib.
+
+## Installation
+
+```bash
+pip install tywrap-ir
+```
 
 ## Usage
 
-```
+```bash
+# Extract IR for a module
 python -m tywrap_ir --module math
-# or
+
+# Or using the CLI
 tywrap-ir --module math
+
+# Output to file
+tywrap-ir --module pandas --output pandas_ir.json
 ```
+
+## What is this?
+
+This package is the Python component of tywrap, a TypeScript wrapper generator for Python libraries. It analyzes Python modules and extracts type information into a JSON intermediate representation (IR) that tywrap uses to generate TypeScript bindings.
+
+You typically don't need to use this package directly - the `tywrap` npm package invokes it automatically during code generation.
+
+## Requirements
+
+- Python 3.10+
+
+## Related
+
+- [tywrap](https://www.npmjs.com/package/tywrap) - The main TypeScript package
+- [GitHub](https://github.com/bbopen/tywrap) - Source code and issues
+
+## License
+
+MIT

--- a/tywrap_ir/pyproject.toml
+++ b/tywrap_ir/pyproject.toml
@@ -3,16 +3,43 @@ requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "tywrap_ir"
-version = "0.0.1"
+name = "tywrap-ir"
+version = "0.1.2"
 description = "Python IR extractor for tywrap: emits versioned JSON IR for Python modules"
 readme = "README.md"
 authors = [
-  { name = "Tywrap Project" }
+  { name = "tywrap contributors" }
+]
+maintainers = [
+  { name = "tywrap contributors" }
 ]
 requires-python = ">=3.10"
 dependencies = []
 license = { text = "MIT" }
+keywords = ["tywrap", "typescript", "python", "bridge", "code-generation", "ast", "ir"]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Software Development :: Code Generators",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+  "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/bbopen/tywrap"
+Repository = "https://github.com/bbopen/tywrap"
+Documentation = "https://github.com/bbopen/tywrap#readme"
+Issues = "https://github.com/bbopen/tywrap/issues"
 
 [project.scripts]
 tywrap-ir = "tywrap_ir.__main__:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["tywrap_ir*"]

--- a/tywrap_ir/tywrap_ir/__init__.py
+++ b/tywrap_ir/tywrap_ir/__init__.py
@@ -1,8 +1,10 @@
 __all__ = [
     "extract_module_ir",
     "IR_VERSION",
+    "__version__",
 ]
 
+__version__ = "0.1.2"
 IR_VERSION = "0.1.0"
 
 from .ir import extract_module_ir  # noqa: E402


### PR DESCRIPTION
## Summary

Sets up the Python package `tywrap-ir` for PyPI publishing, addressing user feedback that the current git-based installation is a significant friction point.

## Changes

- **tywrap_ir/pyproject.toml**: Added proper PyPI metadata (keywords, classifiers, URLs)
- **tywrap_ir/__init__.py**: Added `__version__` attribute
- **tywrap_ir/README.md**: Updated with PyPI badges and installation docs
- **README.md**: Added PyPI badge and `pip install tywrap-ir` instructions
- **.github/workflows/publish-pypi.yml**: New workflow for PyPI releases

## How to Release

After merging, create a tag to trigger the publish workflow:

```bash
git tag tywrap-ir-v0.1.2
git push origin tywrap-ir-v0.1.2
```

## Before First Publish

You'll need to set up PyPI trusted publishing:
1. Go to PyPI → Your projects → Add a new project
2. Configure trusted publisher:
   - Owner: `bbopen`
   - Repository: `tywrap`
   - Workflow: `publish-pypi.yml`
   - Environment: `pypi`

Or add a `PYPI_API_TOKEN` secret to the repository.

## Test plan

- [x] Package builds locally (`python -m build`)
- [ ] CI tests pass
- [ ] Workflow dry-run succeeds

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)