### PR TITLE
fix(ci): run Python API test from /tmp to avoid namespace conflict

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -80,6 +80,7 @@ jobs:
           python -c "import json; data = json.load(open('/tmp/math_ir.json')); print(f'Extracted {len(data.get(\"functions\", []))} functions from math module')"
 
       - name: Test Python API
+        working-directory: /tmp
         run: |
           python -c "from tywrap_ir import extract_module_ir, IR_VERSION, __version__; print(f'IR_VERSION: {IR_VERSION}, __version__: {__version__}')"
 


### PR DESCRIPTION
## Summary

The PyPI publish workflow was failing because the Python API test was finding `tywrap_ir` as a namespace package from the repo root instead of the installed package.

## Fix

Run the test from `/tmp` directory to avoid the namespace conflict.

## Test

- [ ] PyPI publish workflow succeeds

---
Generated with [Claude Code](https://claude.com/claude-code)