### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 TypeScript wrapper for Python libraries with full type safety.
 
-> **⚠️ Experimental Software (v0.1.2)** - APIs may change between versions. Not recommended for production use until v1.0.0.
+> **⚠️ Experimental Software (v0.2.0)** - APIs may change between versions. Not recommended for production use until v1.0.0.
 
 ## Features
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tywrap",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tywrap",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.25.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tywrap",
-  "version": "0.1.2",
-  "description": "TypeScript wrapper for Python libraries with full type safety (EXPERIMENTAL - v0.1.2)",
+  "version": "0.2.0",
+  "description": "TypeScript wrapper for Python libraries with full type safety (EXPERIMENTAL - v0.2.0)",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,7 @@ export {
 } from './utils/codec.js';
 
 // Version info
-export const VERSION = '0.1.2';
+export const VERSION = '0.2.0';
 
 /**
  * Quick setup function for getting started

--- a/tywrap_ir/pyproject.toml
+++ b/tywrap_ir/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tywrap-ir"
-version = "0.1.2"
+version = "0.2.0"
 description = "Python IR extractor for tywrap: emits versioned JSON IR for Python modules"
 readme = "README.md"
 authors = [

--- a/tywrap_ir/tywrap_ir/__init__.py
+++ b/tywrap_ir/tywrap_ir/__init__.py
@@ -4,7 +4,7 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "0.1.2"
+__version__ = "0.2.0"
 IR_VERSION = "0.1.0"
 
 from .ir import extract_module_ir  # noqa: E402


### PR DESCRIPTION
## Summary
- Bump all package versions from 0.1.2 to 0.2.0
- Update version references in README, package.json, src/index.ts, and tywrap_ir

## Changes in v0.2.0
- **Unified NodeBridge** (PR #136): NodeBridge now supports optional worker pooling via `minProcesses`/`maxProcesses` options
- **Deprecated OptimizedNodeBridge**: Now a re-export of NodeBridge for backward compatibility
- **ADR-0001 Complete**: Bridge unification architecture decision implemented
- **Multi-worker adversarial tests**: Comprehensive pool behavior testing

## Breaking Changes
None - fully backward compatible

## Files Changed
- `package.json` / `package-lock.json`
- `src/index.ts`
- `README.md`
- `tywrap_ir/pyproject.toml`
- `tywrap_ir/tywrap_ir/__init__.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)