### PR TITLE
chore: remove stale planning documents

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,0 @@
-# Roadmap
-
-## Runtime Bridges
-
-- [ ] Unify NodeBridge and OptimizedNodeBridge behind a shared JSONL transport core.
-- [ ] Preserve NodeBridge semantics as the baseline (correctness-first, explicit errors).
-- [ ] Make performance features opt-in (process pooling, caching) so defaults stay safe.
-- [ ] When parity is achieved, keep NodeBridge as a thin alias over the unified core.


### PR DESCRIPTION
## Summary
- Delete ROADMAP.md (all items completed via ADR-0001)
- Remove untracked docs/adr/0001-unified-bridge-core.md
- Remove untracked docs/tasks/unified-bridge-core.md

## Context
These planning documents referenced work that has been completed and merged (NodeBridge/OptimizedNodeBridge unification in PR #136). The actual implementation is tracked in git history.

## Test plan
- [x] No code changes, only documentation removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)