### PR TITLE
chore: comprehensive documentation cleanup for v0.2.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Thanks for your interest in contributing!
 
 - Development setup:
-  - Node 20+ and Python 3.12+
+  - Node 20+ and Python 3.10+ (CI tests 3.10, 3.11, 3.12)
   - npm ci
   - npm run check:all
 - Common tasks:

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ You can cap payload sizes with `TYWRAP_CODEC_MAX_BYTES` (responses) and `TYWRAP_
 ```typescript
 import { PyodideBridge } from 'tywrap/pyodide';
 const bridge = new PyodideBridge({
-  indexURL: 'https://cdn.jsdelivr.net/pyodide/v0.24.1/full/'
+  indexURL: 'https://cdn.jsdelivr.net/pyodide/v0.28.0/full/'
 });
 await bridge.init();
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,0 @@
-# Roadmap
-
-## Runtime Bridges
-
-- [ ] Unify NodeBridge and OptimizedNodeBridge behind a shared JSONL transport core.
-- [ ] Preserve NodeBridge semantics as the baseline (correctness-first, explicit errors).
-- [ ] Make performance features opt-in (process pooling, caching) so defaults stay safe.
-- [ ] When parity is achieved, keep NodeBridge as a thin alias over the unified core.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -163,7 +163,7 @@ export default defineConfig({
 {
   "runtime": {
     "pyodide": {
-      "indexURL": "https://cdn.jsdelivr.net/pyodide/",
+      "indexURL": "https://cdn.jsdelivr.net/pyodide/v0.28.0/full/",
       "packages": ["numpy", "scipy", "matplotlib"]
     }
   }
@@ -265,8 +265,6 @@ Use presets to opt into richer mappings for common ecosystems.
   }
 }
 ```
-
-### Development Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -221,7 +221,7 @@ async function demo() {
   },
   "runtime": {
     "pyodide": {
-      "indexURL": "https://cdn.jsdelivr.net/pyodide/",
+      "indexURL": "https://cdn.jsdelivr.net/pyodide/v0.28.0/full/",
       "packages": ["numpy", "scipy"]
     }
   }

--- a/docs/runtimes/browser.md
+++ b/docs/runtimes/browser.md
@@ -25,7 +25,7 @@ npm install tywrap pyodide
   },
   "runtime": {
     "pyodide": {
-      "indexURL": "https://cdn.jsdelivr.net/pyodide/",
+      "indexURL": "https://cdn.jsdelivr.net/pyodide/v0.28.0/full/",
       "packages": ["numpy", "matplotlib", "scipy"]
     }
   }
@@ -39,7 +39,7 @@ import { setRuntimeBridge } from 'tywrap/runtime';
 import { array } from './generated/numpy.generated.js';
 
 const bridge = new PyodideBridge({
-  indexURL: 'https://cdn.jsdelivr.net/pyodide/',
+  indexURL: 'https://cdn.jsdelivr.net/pyodide/v0.28.0/full/',
   packages: ['numpy']
 });
 

--- a/docs/type-mapping-matrix.md
+++ b/docs/type-mapping-matrix.md
@@ -208,7 +208,33 @@ Enable presets via `types.presets` in your config to opt into additional mapping
 
 | Python Type | TypeScript Type | Notes |
 |-------------|----------------|-------|
-| `torch.Tensor` | `{ data: unknown, shape: number[], dtype?: string, device?: string }` | Tensor metadata + decoded data |
+| `torch.Tensor` | Nested ndarray envelope with tensor metadata | See structure below |
+
+Torch tensors are wrapped in a special envelope containing an ndarray:
+```typescript
+{
+  __tywrap__: 'torch.tensor',
+  encoding: 'ndarray',
+  value: {
+    __tywrap__: 'ndarray',
+    encoding: 'json' | 'arrow',
+    value: number[] | Uint8Array,
+    shape: number[],
+    dtype: string
+  },
+  device: string  // e.g., 'cpu'
+}
+```
+
+### pydantic preset
+
+| Python Type | TypeScript Type | Notes |
+|-------------|----------------|-------|
+| `pydantic.BaseModel` | Serialized dict | Via `model_dump(by_alias=True, mode='json')` |
+| Fields with aliases | Uses alias name | `by_alias=True` default |
+
+Pydantic v2 models are serialized using `model_dump()` with `by_alias=True` and `mode='json'`
+to ensure JSON-safe output. Nested models are recursively serialized.
 
 ### sklearn preset
 
@@ -322,4 +348,4 @@ Planned improvements to the type mapping system:
 
 ---
 
-*This document is automatically updated as the type mapping system evolves. Last updated: 2024.*
+*Last updated: January 2026.*

--- a/src/runtime/pyodide-io.ts
+++ b/src/runtime/pyodide-io.ts
@@ -55,7 +55,7 @@ interface PyodideInstance {
 // =============================================================================
 
 /** Default Pyodide CDN URL */
-const DEFAULT_INDEX_URL = 'https://cdn.jsdelivr.net/pyodide/v0.24.1/full/';
+const DEFAULT_INDEX_URL = 'https://cdn.jsdelivr.net/pyodide/v0.28.0/full/';
 
 /**
  * Bootstrap Python code that sets up the dispatch function.

--- a/test/runtime_config.test.ts
+++ b/test/runtime_config.test.ts
@@ -137,7 +137,7 @@ describe('Runtime Configuration', () => {
       const indexURL = (transport as any).indexURL;
       const packages = (transport as any).packages;
 
-      expect(indexURL).toBe('https://cdn.jsdelivr.net/pyodide/v0.24.1/full/');
+      expect(indexURL).toBe('https://cdn.jsdelivr.net/pyodide/v0.28.0/full/');
       expect(packages).toEqual([]);
     });
 
@@ -184,7 +184,7 @@ describe('Runtime Configuration', () => {
     it('should validate CDN URLs', () => {
       const validURLs = [
         'https://cdn.jsdelivr.net/pyodide/',
-        'https://unpkg.com/pyodide@0.24.1/',
+        'https://unpkg.com/pyodide@0.28.0/',
         'https://custom-cdn.example.com/pyodide/',
         'http://localhost:8080/pyodide/', // For development
       ];

--- a/test/runtime_pyodide.test.ts
+++ b/test/runtime_pyodide.test.ts
@@ -110,7 +110,7 @@ describe('Pyodide Runtime Bridge', () => {
       const result = await bridge.call('math', 'sqrt', [16]);
       expect(result).toBe(4);
       expect(mockLoadPyodide).toHaveBeenCalledWith({
-        indexURL: 'https://cdn.jsdelivr.net/pyodide/v0.24.1/full/',
+        indexURL: 'https://cdn.jsdelivr.net/pyodide/v0.28.0/full/',
       });
     });
 
@@ -133,7 +133,7 @@ describe('Pyodide Runtime Bridge', () => {
     it('should initialize with pre-loaded packages', async () => {
       const packages = ['numpy', 'pandas'];
       bridge = new PyodideBridge({
-        indexURL: 'https://cdn.jsdelivr.net/pyodide/v0.24.1/full/',
+        indexURL: 'https://cdn.jsdelivr.net/pyodide/v0.28.0/full/',
         packages,
       });
 
@@ -675,8 +675,8 @@ describe('Pyodide Runtime Bridge', () => {
   describe('CDN and Loading Configurations', () => {
     it('should handle different CDN URLs', async () => {
       const customCDNs = [
-        'https://cdn.jsdelivr.net/pyodide/v0.24.1/',
-        'https://unpkg.com/pyodide@0.24.1/',
+        'https://cdn.jsdelivr.net/pyodide/v0.28.0/',
+        'https://unpkg.com/pyodide@0.28.0/',
         'https://custom-cdn.example.com/pyodide/',
       ];
 


### PR DESCRIPTION
## Summary
Comprehensive documentation cleanup addressing issues identified during v0.2.1 release review.

### Stale Documents Removed
- Delete ROADMAP.md (all items completed via ADR-0001)
- Removed untracked docs/adr/0001-unified-bridge-core.md locally
- Removed untracked docs/tasks/unified-bridge-core.md locally

### Pyodide Version Consistency (v0.24.1 → v0.28.0)
Aligns all Pyodide URLs with the `>=0.28.0` peer dependency:
- `src/runtime/pyodide-io.ts` - DEFAULT_INDEX_URL
- `README.md` - browser example
- `docs/runtimes/browser.md` - examples
- `docs/getting-started.md` - example
- `docs/configuration.md` - example
- `test/runtime_pyodide.test.ts` - expectations
- `test/runtime_config.test.ts` - expectations

### CONTRIBUTING.md Fix
- Fix Python version requirement: 3.12+ → 3.10+ (matches CI matrix which tests 3.10, 3.11, 3.12)

### type-mapping-matrix.md Improvements
- Remove false "automatically updated" claim
- Fix year: 2024 → January 2026
- Add Pydantic v2 BaseModel documentation
- Fix torch.Tensor to show nested ndarray envelope structure

### configuration.md Fix
- Remove duplicate "Development Options" header (was at lines 258 and 269)

## Test plan
- [x] `npm run build && npm run typecheck` passes
- [x] Pyodide-related tests pass: `npx vitest run test/runtime_pyodide.test.ts test/runtime_config.test.ts`
- [x] No remaining v0.24.1 references: `grep -r "0.24.1" docs/ README.md src/ test/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)