### PR TITLE
runtime-node: make instance handle lifecycle errors explicit

### DIFF
--- a/runtime/python_bridge.py
+++ b/runtime/python_bridge.py
@@ -138,6 +138,10 @@ class ProtocolError(Exception):
     pass
 
 
+class InstanceHandleError(ValueError):
+    """Raised when an instance handle is unknown or no longer valid."""
+
+
 _PROTOCOL_DIAGNOSTIC_MAX = 2048
 
 
@@ -668,7 +672,7 @@ def handle_call_method(params):
     args = coerce_list(params.get('args'), 'args')
     kwargs = coerce_dict(params.get('kwargs'), 'kwargs')
     if handle_id not in instances:
-        raise KeyError(f'Unknown handle: {handle_id}')
+        raise InstanceHandleError(f'Unknown instance handle: {handle_id}')
     obj = instances[handle_id]
     func = getattr(obj, method_name)
     res = func(*args, **kwargs)
@@ -678,7 +682,7 @@ def handle_call_method(params):
 def handle_dispose_instance(params):
     handle_id = require_str(params, 'handle')
     if handle_id not in instances:
-        raise KeyError(f'Unknown handle: {handle_id}')
+        return False
     del instances[handle_id]
     return True
 

--- a/test/runtime_node.test.ts
+++ b/test/runtime_node.test.ts
@@ -323,7 +323,23 @@ def get_path():
         const handle = await bridge.instantiate('collections', 'Counter', [[1, 2, 2]]);
         await bridge.disposeInstance(handle);
 
-        await expect(bridge.callMethod(handle, 'most_common', [1])).rejects.toThrow();
+        await expect(bridge.callMethod(handle, 'most_common', [1])).rejects.toThrow(
+          /InstanceHandleError: Unknown instance handle:/
+        );
+      },
+      testTimeout
+    );
+
+    it(
+      'should allow disposing the same instance handle twice',
+      async () => {
+        const pythonAvailable = await isPythonAvailable();
+        if (!pythonAvailable || !isBridgeScriptAvailable()) return;
+
+        const handle = await bridge.instantiate('collections', 'Counter', [[1, 2, 2]]);
+        await bridge.disposeInstance(handle);
+
+        await expect(bridge.disposeInstance(handle)).resolves.toBeUndefined();
       },
       testTimeout
     );


### PR DESCRIPTION
## Summary
- add explicit `InstanceHandleError` for missing instance handles in `call_method`
- make `dispose_instance` idempotent by returning `False` for already-disposed handles instead of raising
- add runtime and adversarial test coverage for missing-handle behavior and double-dispose safety

## Validation
- `npx eslint test/runtime_node.test.ts test/adversarial_playground.test.ts`
- `npm test -- test/runtime_node.test.ts`
- `TYWRAP_ADVERSARIAL=1 npm test -- test/adversarial_playground.test.ts`

Closes #49
