### PR TITLE
runtime-http: handle circular serialization failures as protocol errors

### DIFF
--- a/src/runtime/validators.ts
+++ b/src/runtime/validators.ts
@@ -183,17 +183,28 @@ export function assertObject(value: unknown, name: string): Record<string, unkno
  * @param value - The value to check
  * @returns True if the value contains NaN or Infinity anywhere
  */
-export function containsSpecialFloat(value: unknown): boolean {
+function containsSpecialFloatRecursive(value: unknown, visited: WeakSet<object>): boolean {
   if (typeof value === 'number') {
     return !Number.isFinite(value);
   }
+  if (value === null || typeof value !== 'object') {
+    return false;
+  }
+  if (visited.has(value)) {
+    return false;
+  }
+  visited.add(value);
   if (Array.isArray(value)) {
-    return value.some(containsSpecialFloat);
+    return value.some(item => containsSpecialFloatRecursive(item, visited));
   }
   if (isPlainObject(value)) {
-    return Object.values(value).some(containsSpecialFloat);
+    return Object.values(value).some(item => containsSpecialFloatRecursive(item, visited));
   }
   return false;
+}
+
+export function containsSpecialFloat(value: unknown): boolean {
+  return containsSpecialFloatRecursive(value, new WeakSet<object>());
 }
 
 /**

--- a/test/runtime_http.test.ts
+++ b/test/runtime_http.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { BridgeProtocolError } from '../src/runtime/errors.js';
+import { HttpBridge } from '../src/runtime/http.js';
+
+const originalFetch = globalThis.fetch;
+
+describe('HttpBridge serialization guardrails', () => {
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    globalThis.fetch = originalFetch;
+  });
+
+  it('surfaces BigInt args serialization failures as BridgeProtocolError', async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const bridge = new HttpBridge({ baseURL: 'http://localhost:8000' });
+    try {
+      try {
+        await bridge.call('math', 'sqrt', [1n]);
+        expect.fail('Expected serialization failure');
+      } catch (error) {
+        expect(error).toBeInstanceOf(BridgeProtocolError);
+        const message = error instanceof Error ? error.message : String(error);
+        expect(message).toMatch(/JSON serialization failed/i);
+      }
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      await bridge.dispose();
+    }
+  });
+
+  it('surfaces circular args serialization failures as BridgeProtocolError', async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const circular: { self?: unknown } = {};
+    circular.self = circular;
+
+    const bridge = new HttpBridge({ baseURL: 'http://localhost:8000' });
+    try {
+      try {
+        await bridge.call('math', 'sqrt', [circular]);
+        expect.fail('Expected serialization failure');
+      } catch (error) {
+        expect(error).toBeInstanceOf(BridgeProtocolError);
+        const message = error instanceof Error ? error.message : String(error);
+        expect(message).toMatch(/JSON serialization failed/i);
+      }
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      await bridge.dispose();
+    }
+  });
+});

--- a/test/safe-codec.test.ts
+++ b/test/safe-codec.test.ts
@@ -248,20 +248,15 @@ describe('encodeRequest - Size Limits', () => {
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe('encodeRequest - Serialization Errors', () => {
-  it('circular references throw an error', () => {
-    // Use rejectSpecialFloats: false to avoid stack overflow during float validation
-    // The error will be caught during JSON.stringify instead
-    const codec = new SafeCodec({ rejectSpecialFloats: false });
+  it('circular references throw BridgeProtocolError by default', () => {
+    const codec = new SafeCodec();
     const circular: Record<string, unknown> = { a: 1 };
     circular.self = circular;
-    // Circular references will throw either RangeError (stack overflow during validation)
-    // or BridgeProtocolError (caught during JSON.stringify)
-    expect(() => codec.encodeRequest(circular)).toThrow();
+    expect(() => codec.encodeRequest(circular)).toThrow(BridgeProtocolError);
+    expect(() => codec.encodeRequest(circular)).toThrow(/JSON serialization failed/);
   });
 
-  it('circular references throw BridgeProtocolError when skipping float validation', () => {
-    // When rejectSpecialFloats is false, we skip the recursive float check
-    // and the error will be caught during JSON.stringify, wrapped in BridgeProtocolError
+  it('circular references throw BridgeProtocolError when validation guardrails are disabled', () => {
     const codec = new SafeCodec({ rejectSpecialFloats: false, rejectNonStringKeys: false });
     const circular: Record<string, unknown> = { a: 1 };
     circular.self = circular;


### PR DESCRIPTION
## Summary
- prevent recursive validation from overflowing on circular values by adding cycle detection in codec/validator traversal
- ensure circular and BigInt serialization failures are surfaced as `BridgeProtocolError` before transport send
- add HttpBridge regression tests to verify serialization failures happen before `fetch`

## Testing
- npx eslint src/runtime/validators.ts src/runtime/safe-codec.ts test/validators.test.ts test/safe-codec.test.ts test/runtime_http.test.ts
- npm run typecheck
- npm test -- test/validators.test.ts test/safe-codec.test.ts test/runtime_http.test.ts
- npm test -- test/bridge-protocol.test.ts

Closes #120
