### PR TITLE
runtime-node: surface explicit TYWRAP_CODEC_MAX_BYTES startup errors

### DIFF
--- a/test/adversarial_playground.test.ts
+++ b/test/adversarial_playground.test.ts
@@ -158,6 +158,25 @@ describeAdversarial('Adversarial playground', () => {
   );
 
   it(
+    'surfaces invalid TYWRAP_CODEC_MAX_BYTES as an explicit startup error',
+    async () => {
+      const bridge = await createBridge({
+        env: { TYWRAP_CODEC_MAX_BYTES: 'not-a-number' },
+      });
+      if (!bridge) return;
+
+      try {
+        await expect(callAdversarial(bridge, 'echo', ['value'])).rejects.toThrow(
+          /TYWRAP_CODEC_MAX_BYTES/
+        );
+      } finally {
+        await bridge.dispose();
+      }
+    },
+    testTimeoutMs
+  );
+
+  it(
     'rejects requests that exceed TYWRAP_REQUEST_MAX_BYTES',
     async () => {
       const bridge = await createBridge({


### PR DESCRIPTION
## Summary
- include captured stderr context in ProcessIO stdin/write stream errors so startup failures retain root-cause diagnostics
- add a deterministic transport regression test for write-time EPIPE/error paths carrying `TYWRAP_CODEC_MAX_BYTES` details
- add adversarial coverage for invalid `TYWRAP_CODEC_MAX_BYTES` values

## Testing
- npx eslint src/runtime/process-io.ts test/transport.test.ts test/adversarial_playground.test.ts
- npm run typecheck
- npm test -- test/transport.test.ts
- npm test -- test/runtime_node.test.ts -t "TYWRAP_CODEC_MAX_BYTES"
- TYWRAP_ADVERSARIAL=1 npm test -- test/adversarial_playground.test.ts -t "invalid TYWRAP_CODEC_MAX_BYTES"

Closes #52
