### PR TITLE
runtime-http: make error payload/timeout/invalid-json failures explicit

### DIFF
--- a/src/runtime/safe-codec.ts
+++ b/src/runtime/safe-codec.ts
@@ -60,7 +60,7 @@ interface ProtocolEnvelope {
 // ═══════════════════════════════════════════════════════════════════════════
 
 const DEFAULT_MAX_PAYLOAD_BYTES = 10 * 1024 * 1024; // 10MB
-const ERROR_PAYLOAD_SNIPPET_BYTES = 200;
+const ERROR_PAYLOAD_SNIPPET_LENGTH = 200;
 
 // ═══════════════════════════════════════════════════════════════════════════
 // HELPER FUNCTIONS
@@ -224,10 +224,10 @@ function summarizePayloadForError(payload: string): string {
   if (!trimmed) {
     return '[empty payload]';
   }
-  if (trimmed.length <= ERROR_PAYLOAD_SNIPPET_BYTES) {
+  if (trimmed.length <= ERROR_PAYLOAD_SNIPPET_LENGTH) {
     return trimmed;
   }
-  return `${trimmed.slice(0, ERROR_PAYLOAD_SNIPPET_BYTES)}...`;
+  return `${trimmed.slice(0, ERROR_PAYLOAD_SNIPPET_LENGTH)}...`;
 }
 
 /**

--- a/test/runtime_http.test.ts
+++ b/test/runtime_http.test.ts
@@ -172,13 +172,16 @@ describe('HttpBridge runtime error handling', () => {
 
   it('surfaces consistent timeout errors with context', async () => {
     await withHttpFixture((_, res) => {
-      setTimeout(() => {
+      const timer = setTimeout(() => {
         if (!res.writableEnded) {
           res.statusCode = 200;
           res.setHeader('Content-Type', 'application/json');
           res.end(JSON.stringify({ id: 1, result: 4 }));
         }
       }, 200);
+      res.on('close', () => {
+        clearTimeout(timer);
+      });
     }, async baseURL => {
       const bridge = new HttpBridge({ baseURL, timeoutMs: 50 });
       try {


### PR DESCRIPTION
## Summary
- include payload snippets in `SafeCodec` JSON parse failures so invalid HTTP response bodies surface actionable context
- add local HTTP fixture tests for `HttpBridge` to cover invalid JSON, top-level `{error}` payloads, HTTP 500 JSON bodies, and timeout behavior
- assert explicit bridge error types/messages for each runtime-http failure mode

## Testing
- npx eslint src/runtime/safe-codec.ts test/runtime_http.test.ts
- npm run typecheck
- npm test -- test/runtime_http.test.ts
- npm test -- test/safe-codec.test.ts
- npm test -- test/runtime_http.test.ts test/safe-codec.test.ts test/transport.test.ts

Closes #56
