### PR TITLE
fix(runtime): correlate ProcessIO responses by top-level id

### DIFF
--- a/test/runtime_node.test.ts
+++ b/test/runtime_node.test.ts
@@ -113,6 +113,19 @@ describeNodeOnly('Node.js Runtime Bridge', () => {
     );
 
     it(
+      'should not timeout when args include nested id fields',
+      async () => {
+        const pythonAvailable = await isPythonAvailable();
+        if (!pythonAvailable || !isBridgeScriptAvailable()) return;
+
+        const result = await bridge.call<string>('builtins', 'str', [{ id: 999, value: 'ok' }]);
+        expect(result).toContain("'id': 999");
+        expect(result).toContain("'value': 'ok'");
+      },
+      testTimeout
+    );
+
+    it(
       'should roundtrip Uint8Array as Python bytes',
       async () => {
         const pythonAvailable = await isPythonAvailable();


### PR DESCRIPTION
## Summary\n- replace regex ID extraction with strict top-level JSON id parsing in ProcessIO\n- treat id=0 as a valid request/response correlation key\n- add regressions for nested payload `id` values and id=0\n\n## Validation\n- npx vitest --run test/transport.test.ts test/runtime_node.test.ts