### PR TITLE
fix(runtime): align Node warmup protocol and fail fast

### DIFF
--- a/src/runtime/node.ts
+++ b/src/runtime/node.ts
@@ -74,7 +74,8 @@ export interface NodeBridgeOptions {
 
   /** Commands to run on each process at startup for warming up. */
   warmupCommands?: Array<
-    { module: string; functionName: string; args?: unknown[] } | { method: string; params: unknown } // Legacy format for backwards compatibility
+    | { module: string; functionName: string; args?: unknown[] }
+    | { method: string; params: unknown } // Legacy shape preserved so runtime can surface a migration error
   >;
 
   // ===========================================================================
@@ -196,7 +197,14 @@ function assertSafeEnvOverrideKey(key: string): void {
 }
 
 function normalizeWarmupCommands(commands: NodeBridgeOptions['warmupCommands']): WarmupCommand[] {
-  const warmups = commands ?? [];
+  if (commands === undefined) {
+    return [];
+  }
+  if (!Array.isArray(commands)) {
+    throw new BridgeProtocolError('warmupCommands must be an array when provided');
+  }
+
+  const warmups = commands;
   return warmups.map((command, index) => {
     if (!command || typeof command !== 'object' || Array.isArray(command)) {
       throw new BridgeProtocolError(
@@ -549,17 +557,26 @@ function createWarmupCallback(
   return async (worker: PooledWorker) => {
     for (const [index, cmd] of warmupCommands.entries()) {
       const commandLabel = `${cmd.module}.${cmd.functionName}`;
-      const message = JSON.stringify({
-        id: generateWarmupId(),
-        protocol: PROTOCOL_ID,
-        method: 'call',
-        params: {
-          module: cmd.module,
-          functionName: cmd.functionName,
-          args: cmd.args ?? [],
-          kwargs: {},
-        },
-      });
+      const requestId = generateWarmupId();
+      let message: string;
+      try {
+        message = JSON.stringify({
+          id: requestId,
+          protocol: PROTOCOL_ID,
+          method: 'call',
+          params: {
+            module: cmd.module,
+            functionName: cmd.functionName,
+            args: cmd.args ?? [],
+            kwargs: {},
+          },
+        });
+      } catch (error) {
+        throw new BridgeExecutionError(
+          `Warmup command #${index + 1} (${commandLabel}) failed to encode request: ${error instanceof Error ? error.message : String(error)}`,
+          { cause: error instanceof Error ? error : undefined }
+        );
+      }
 
       let response: string;
       try {
@@ -581,8 +598,15 @@ function createWarmupCallback(
         );
       }
 
-      if (parsed && typeof parsed === 'object' && 'error' in parsed) {
-        const errorPayload = (parsed as { error?: unknown }).error;
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        throw new BridgeExecutionError(
+          `Warmup command #${index + 1} (${commandLabel}) returned malformed response envelope for request ${requestId}`
+        );
+      }
+
+      const envelope = parsed as { result?: unknown; error?: unknown };
+      if ('error' in envelope && envelope.error !== undefined && envelope.error !== null) {
+        const errorPayload = envelope.error;
         if (errorPayload && typeof errorPayload === 'object' && !Array.isArray(errorPayload)) {
           const err = errorPayload as { type?: unknown; message?: unknown };
           const errType = typeof err.type === 'string' ? err.type : 'Error';
@@ -595,6 +619,12 @@ function createWarmupCallback(
 
         throw new BridgeExecutionError(
           `Warmup command #${index + 1} (${commandLabel}) failed with malformed error payload`
+        );
+      }
+
+      if (!('result' in envelope)) {
+        throw new BridgeExecutionError(
+          `Warmup command #${index + 1} (${commandLabel}) returned malformed response envelope for request ${requestId}`
         );
       }
     }

--- a/test/optimized-node.test.ts
+++ b/test/optimized-node.test.ts
@@ -86,6 +86,20 @@ describe('OptimizedNodeBridge', () => {
       expect(createBridge).toThrow(/legacy \{ method, params \} format is no longer supported/i);
     });
 
+    it('should reject non-array warmupCommands', () => {
+      const createBridge = (): OptimizedNodeBridge =>
+        new OptimizedNodeBridge({
+          warmupCommands: {
+            module: 'math',
+            functionName: 'sqrt',
+            args: [16],
+          } as unknown as Array<{ module: string; functionName: string; args?: unknown[] }>,
+        });
+
+      expect(createBridge).toThrow(BridgeProtocolError);
+      expect(createBridge).toThrow(/warmupCommands must be an array/i);
+    });
+
     it('should accept custom environment variables', () => {
       bridge = new OptimizedNodeBridge({
         env: {

--- a/test/runtime_node.test.ts
+++ b/test/runtime_node.test.ts
@@ -6,7 +6,7 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
 import { spawn } from 'child_process';
 import { existsSync } from 'fs';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { access, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { delimiter, join } from 'path';
 import { NodeBridge } from '../src/runtime/node.js';
@@ -711,6 +711,97 @@ def get_bad():
         expect(result).toBe(5);
 
         await fallbackBridge.dispose();
+      },
+      testTimeout
+    );
+  });
+
+  describe('Warmup Commands', () => {
+    it(
+      'should execute warmup commands during init',
+      async () => {
+        const pythonAvailable = await isPythonAvailable();
+        if (!pythonAvailable || !isBridgeScriptAvailable()) return;
+
+        let tempDir: string | undefined;
+        let warmupBridge: NodeBridge | undefined;
+        try {
+          tempDir = await mkdtemp(join(tmpdir(), 'tywrap-warmup-'));
+          const moduleName = 'warmup_fixture';
+          const markerPath = join(tempDir, 'warmup.marker');
+          const modulePath = join(tempDir, `${moduleName}.py`);
+
+          await writeFile(
+            modulePath,
+            `from pathlib import Path\n\ndef touch(path):\n    Path(path).write_text('warmed', encoding='utf-8')\n    return True\n`,
+            'utf-8'
+          );
+
+          const existingPyPath = process.env.PYTHONPATH;
+          const mergedPyPath = existingPyPath ? `${tempDir}${delimiter}${existingPyPath}` : tempDir;
+
+          warmupBridge = new NodeBridge({
+            scriptPath,
+            env: { PYTHONPATH: mergedPyPath },
+            warmupCommands: [{ module: moduleName, functionName: 'touch', args: [markerPath] }],
+            timeoutMs: defaultTimeoutMs,
+          });
+
+          await warmupBridge.init();
+          await expect(access(markerPath)).resolves.toBeUndefined();
+        } finally {
+          if (warmupBridge) {
+            await warmupBridge.dispose();
+          }
+          if (tempDir) {
+            await rm(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+          }
+        }
+      },
+      testTimeout
+    );
+
+    it(
+      'should surface warmup failures and keep bridge not ready',
+      async () => {
+        const pythonAvailable = await isPythonAvailable();
+        if (!pythonAvailable || !isBridgeScriptAvailable()) return;
+
+        let tempDir: string | undefined;
+        let warmupBridge: NodeBridge | undefined;
+        try {
+          tempDir = await mkdtemp(join(tmpdir(), 'tywrap-warmup-fail-'));
+          const moduleName = 'warmup_failure_fixture';
+          const modulePath = join(tempDir, `${moduleName}.py`);
+
+          await writeFile(
+            modulePath,
+            `def fail():\n    raise RuntimeError('warmup boom')\n`,
+            'utf-8'
+          );
+
+          const existingPyPath = process.env.PYTHONPATH;
+          const mergedPyPath = existingPyPath ? `${tempDir}${delimiter}${existingPyPath}` : tempDir;
+
+          warmupBridge = new NodeBridge({
+            scriptPath,
+            env: { PYTHONPATH: mergedPyPath },
+            warmupCommands: [{ module: moduleName, functionName: 'fail' }],
+            timeoutMs: defaultTimeoutMs,
+          });
+
+          const initPromise = warmupBridge.init();
+          await expect(initPromise).rejects.toThrow(/Warmup command #1/);
+          await expect(initPromise).rejects.toThrow(/RuntimeError: warmup boom/);
+          expect(warmupBridge.isReady).toBe(false);
+        } finally {
+          if (warmupBridge) {
+            await warmupBridge.dispose();
+          }
+          if (tempDir) {
+            await rm(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+          }
+        }
       },
       testTimeout
     );

--- a/test/runtime_node.test.ts
+++ b/test/runtime_node.test.ts
@@ -805,6 +805,82 @@ def get_bad():
       },
       testTimeout
     );
+
+    it(
+      'should surface warmup request encoding failures with command context',
+      async () => {
+        const pythonAvailable = await isPythonAvailable();
+        if (!pythonAvailable || !isBridgeScriptAvailable()) return;
+
+        let warmupBridge: NodeBridge | undefined;
+        try {
+          warmupBridge = new NodeBridge({
+            scriptPath,
+            warmupCommands: [{ module: 'math', functionName: 'sqrt', args: [BigInt(16)] }],
+            timeoutMs: defaultTimeoutMs,
+          });
+
+          const initPromise = warmupBridge.init();
+          await expect(initPromise).rejects.toThrow(/Warmup command #1 \(math\.sqrt\)/);
+          await expect(initPromise).rejects.toThrow(/failed to encode request/i);
+          expect(warmupBridge.isReady).toBe(false);
+        } finally {
+          if (warmupBridge) {
+            await warmupBridge.dispose();
+          }
+        }
+      },
+      testTimeout
+    );
+
+    it(
+      'should reject malformed warmup success envelopes',
+      async () => {
+        const pythonAvailable = await isPythonAvailable();
+        if (!pythonAvailable) return;
+
+        let tempDir: string | undefined;
+        let warmupBridge: NodeBridge | undefined;
+        try {
+          tempDir = await mkdtemp(join(tmpdir(), 'tywrap-warmup-envelope-'));
+          const malformedBridgePath = join(tempDir, 'malformed_bridge.py');
+
+          await writeFile(
+            malformedBridgePath,
+            [
+              'import json',
+              'import sys',
+              '',
+              'for line in sys.stdin:',
+              '    request = json.loads(line)',
+              "    response = {'id': request.get('id'), 'protocol': request.get('protocol')}",
+              "    sys.stdout.write(json.dumps(response) + '\\n')",
+              '    sys.stdout.flush()',
+            ].join('\n'),
+            'utf-8'
+          );
+
+          warmupBridge = new NodeBridge({
+            scriptPath: malformedBridgePath,
+            warmupCommands: [{ module: 'math', functionName: 'sqrt', args: [16] }],
+            timeoutMs: defaultTimeoutMs,
+          });
+
+          const initPromise = warmupBridge.init();
+          await expect(initPromise).rejects.toThrow(/Warmup command #1 \(math\.sqrt\)/);
+          await expect(initPromise).rejects.toThrow(/malformed response envelope/i);
+          expect(warmupBridge.isReady).toBe(false);
+        } finally {
+          if (warmupBridge) {
+            await warmupBridge.dispose();
+          }
+          if (tempDir) {
+            await rm(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+          }
+        }
+      },
+      testTimeout
+    );
   });
 
   describe('Data Transfer and Serialization', () => {


### PR DESCRIPTION
## Summary\n- send warmup commands with the current protocol envelope (protocol/method/params + numeric id)\n- reject legacy warmup shape `{ method, params }` with explicit migration guidance\n- surface warmup send/response failures with command index + module/function context\n- ensure WorkerPool disposes transports and does not retain workers when warmup fails\n\n## Validation\n- npx vitest --run test/runtime_node.test.ts test/optimized-node.test.ts test/worker-pool.test.ts