### PR TITLE
fix(pyodide): align bootstrap dispatcher with protocol envelope

### DIFF
--- a/src/runtime/transport.ts
+++ b/src/runtime/transport.ts
@@ -122,7 +122,12 @@ export interface ProtocolResponse {
  * await transport.init();
  *
  * const response = await transport.send(
- *   JSON.stringify({ id: '1', type: 'call', module: 'math', functionName: 'sqrt', args: [16] }),
+ *   JSON.stringify({
+ *     id: 1,
+ *     protocol: 'tywrap/1',
+ *     method: 'call',
+ *     params: { module: 'math', functionName: 'sqrt', args: [16], kwargs: {} },
+ *   }),
  *   5000
  * );
  *


### PR DESCRIPTION
## Summary\n- rewrite Pyodide bootstrap dispatcher to consume `protocol` + `method` + `params`\n- return protocol-aligned envelopes with numeric ids and protocol echo\n- update runtime protocol examples/comments still using obsolete `type` shape\n- add transport-level regressions for legacy shape rejection and unknown-method errors\n\n## Validation\n- npx vitest --run test/transport.test.ts test/runtime_pyodide.test.ts