### PR TITLE
test(pyodide): harden protocol contract drift coverage

### DIFF
--- a/src/runtime/transport.ts
+++ b/src/runtime/transport.ts
@@ -122,7 +122,12 @@ export interface ProtocolResponse {
  * await transport.init();
  *
  * const response = await transport.send(
- *   JSON.stringify({ id: '1', type: 'call', module: 'math', functionName: 'sqrt', args: [16] }),
+ *   JSON.stringify({
+ *     id: 1,
+ *     protocol: 'tywrap/1',
+ *     method: 'call',
+ *     params: { module: 'math', functionName: 'sqrt', args: [16], kwargs: {} },
+ *   }),
  *   5000
  * );
  *


### PR DESCRIPTION
## Summary\n- harden Pyodide test mocks to validate request envelope contract (id/protocol/method/params)\n- replace permissive assertions with behavior checks on dispatched protocol shape\n- add negative coverage proving drifted envelopes are rejected\n\n## Stack\n- base branch: `codex/fix-pyodide-bootstrap-protocol` (PR #197)\n\n## Validation\n- npx vitest --run test/runtime_pyodide.test.ts test/transport.test.ts