### PR TITLE
[codex] Release prep for tywrap 0.3.0 and tywrap-ir 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+## [0.3.0](https://github.com/bbopen/tywrap/compare/v0.2.1...v0.3.0) (2026-03-22)
+
+
+### Features
+
+* **docs:** add 3D hero visual — cinematic particle network ([#212](https://github.com/bbopen/tywrap/issues/212)) ([5740a4e](https://github.com/bbopen/tywrap/commit/5740a4e28d7703709461d741c79f75806ccc9f61))
+* **docs:** redesign hero with llm copy block and extracted features ([#213](https://github.com/bbopen/tywrap/issues/213)) ([7875db3](https://github.com/bbopen/tywrap/commit/7875db30bd97d4ea481fd4a0bba5ecc368e0ebf8))
+* **runtime:** add getBridgeInfo() meta call ([#188](https://github.com/bbopen/tywrap/issues/188)) ([bd16412](https://github.com/bbopen/tywrap/commit/bd16412de59d1499c769b574a3fa39a009ed1fab))
+* tywrap promotion, docs site, and maintenance automation ([bab9301](https://github.com/bbopen/tywrap/commit/bab9301b3df6eab81ce7229ea701489d3f9b33e2))
+
+
+### Bug Fixes
+
+* address follow-up promotion bugs ([4342335](https://github.com/bbopen/tywrap/commit/434233588ea097bfc9538991067f7b4cbbcf7007))
+* address PR 207 review comments ([31dfda4](https://github.com/bbopen/tywrap/commit/31dfda455f58def859268005c948118794f7ff28))
+* address PR 207 ruff import review ([d248b9e](https://github.com/bbopen/tywrap/commit/d248b9e27cf04eb140180b0885127b5dd98b3183))
+* address review findings across docs, CI, and metadata ([27f47a2](https://github.com/bbopen/tywrap/commit/27f47a28970d0feb58dc1e241ba3763eaf1f8617))
+* **analyzer:** support tree-sitter 0.25 grammar exports ([c38a155](https://github.com/bbopen/tywrap/commit/c38a1550ab858f0f0f5dc0da31df5a90a0423a56))
+* **ci:** resolve @types/react peer dep conflict breaking npm ci ([8228937](https://github.com/bbopen/tywrap/commit/8228937cae232487011c0bf8c833690110180973))
+* **pyodide:** align bootstrap dispatcher with protocol envelope ([#197](https://github.com/bbopen/tywrap/issues/197)) ([79e6a95](https://github.com/bbopen/tywrap/commit/79e6a95a09c292540a13bbf2c4b7833764ddb24d))
+* **runtime:** align Node warmup protocol and fail fast ([#196](https://github.com/bbopen/tywrap/issues/196)) ([30f4a40](https://github.com/bbopen/tywrap/commit/30f4a407d26efec26153c067fcf1b2aead826b9c))
+* **runtime:** avoid empty PATH entries ([48adce8](https://github.com/bbopen/tywrap/commit/48adce861be5b675125d295323a88a1d4a8a2294))
+* **runtime:** harden advanced typing and worker recovery ([4942383](https://github.com/bbopen/tywrap/commit/4942383ea0ece6b75b8ce99adc05fc1fe1056482))
+* **runtime:** normalize worker thread errors ([9ffed1e](https://github.com/bbopen/tywrap/commit/9ffed1e651c94a614b54caecd0095e1a0e77c00e))
+* **runtime:** preserve POSIX path aliases ([8fd9e37](https://github.com/bbopen/tywrap/commit/8fd9e3789c992b4ef8997b243180ca1debc49bce))
+* **types:** unblock py310 advanced typing ([18ff997](https://github.com/bbopen/tywrap/commit/18ff997eeaf9f4a603c72a260b7d81ff5f3c73d2))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Features
 
+* safe TypeScript generic emission ([#210](https://github.com/bbopen/tywrap/issues/210)) ([c977786](https://github.com/bbopen/tywrap/commit/c977786b48ae9f8d4043569fe7ade105313a23f1))
 * **docs:** add 3D hero visual — cinematic particle network ([#212](https://github.com/bbopen/tywrap/issues/212)) ([5740a4e](https://github.com/bbopen/tywrap/commit/5740a4e28d7703709461d741c79f75806ccc9f61))
 * **docs:** redesign hero with llm copy block and extracted features ([#213](https://github.com/bbopen/tywrap/issues/213)) ([7875db3](https://github.com/bbopen/tywrap/commit/7875db30bd97d4ea481fd4a0bba5ecc368e0ebf8))
 * **runtime:** add getBridgeInfo() meta call ([#188](https://github.com/bbopen/tywrap/issues/188)) ([bd16412](https://github.com/bbopen/tywrap/commit/bd16412de59d1499c769b574a3fa39a009ed1fab))

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ npx tywrap init        # Create config (and package.json scripts if present)
 npx tywrap generate    # Generate wrappers
 ```
 
+`tywrap` and `tywrap-ir` are versioned independently. Install the latest
+published release of each package unless you need to pin them explicitly.
+
 For CI (or to verify a dependency upgrade didn’t change the generated surface):
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ TypeScript wrapper for Python libraries with full type safety.
 
 - **Full Type Safety** - TypeScript definitions generated from Python source
   analysis
+- **Generic-Aware Declarations** - Preserves simple `TypeVar` and callable
+  `ParamSpec` generics in generated `.ts` and `.d.ts` output
 - **Multi-Runtime** - Node.js (subprocess) and browsers (Pyodide)
 - **Rich Data Types** - numpy, pandas, scipy, torch, sklearn, and stdlib types
 - **Efficient Serialization** - Apache Arrow binary format with JSON fallback

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -167,7 +167,7 @@ decorator helpers: `dataclass`, `property`, `staticmethod`, `classmethod`,
 | ---------------- | -------------------------- | --------------- | --------------------------------- |
 | `dir`            | `string`                   | `'./generated'` | Output directory                  |
 | `format`         | `'esm' \| 'cjs' \| 'both'` | `'esm'`         | Module format                     |
-| `declaration`    | `boolean`                  | `false`         | Generate .d.ts files              |
+| `declaration`    | `boolean`                  | `false`         | Generate matching `.d.ts` files, including preserved simple generics when representable |
 | `sourceMap`      | `boolean`                  | `false`         | Generate source maps              |
 | `annotatedJSDoc` | `boolean`                  | `false`         | Include type annotations in JSDoc |
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -30,6 +30,16 @@ bun add tywrap
 deno add npm:tywrap
 ```
 
+Install the Python IR extractor in the environment that will run code
+generation:
+
+```bash
+pip install tywrap-ir
+```
+
+`tywrap` and `tywrap-ir` are versioned independently. Install the latest
+published release of each package unless you need to pin them explicitly.
+
 ## Configuration
 
 Create a `tywrap.config.ts` in your project root (or run `npx tywrap init`):

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,10 +7,13 @@ layout: home
 
 ```bash
 npm install tywrap
-pip install tywrap-ir
+pip install tywrap-ir  # Python component for code generation
 npx tywrap init
 npx tywrap generate
 ```
+
+`tywrap` and `tywrap-ir` are versioned independently. Install the latest
+published release of each package unless you need to pin them explicitly.
 
 ```typescript
 import { NodeBridge } from 'tywrap/node';

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -13,10 +13,13 @@ layout: home
 
 ```bash
 npm install tywrap
-pip install tywrap-ir
+pip install tywrap-ir  # Python component for code generation
 npx tywrap init
 npx tywrap generate
 ```
+
+`tywrap` and `tywrap-ir` are versioned independently. Install the latest
+published release of each package unless you need to pin them explicitly.
 
 ```typescript
 import { NodeBridge } from 'tywrap/node';
@@ -65,6 +68,16 @@ bun add tywrap
 # deno
 deno add npm:tywrap
 ```
+
+Install the Python IR extractor in the environment that will run code
+generation:
+
+```bash
+pip install tywrap-ir
+```
+
+`tywrap` and `tywrap-ir` are versioned independently. Install the latest
+published release of each package unless you need to pin them explicitly.
 
 ## Configuration
 

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -596,7 +596,7 @@ decorator helpers: `dataclass`, `property`, `staticmethod`, `classmethod`,
 | ---------------- | -------------------------- | --------------- | --------------------------------- |
 | `dir`            | `string`                   | `'./generated'` | Output directory                  |
 | `format`         | `'esm' \| 'cjs' \| 'both'` | `'esm'`         | Module format                     |
-| `declaration`    | `boolean`                  | `false`         | Generate .d.ts files              |
+| `declaration`    | `boolean`                  | `false`         | Generate matching `.d.ts` files, including preserved simple generics when representable |
 | `sourceMap`      | `boolean`                  | `false`         | Generate source maps              |
 | `annotatedJSDoc` | `boolean`                  | `false`         | Include type annotations in JSDoc |
 
@@ -2103,7 +2103,7 @@ npx tywrap generate --modules math,statistics --runtime node
 | `--python`                            | Python executable path override                                     |
 | `--output-dir`                        | Override `output.dir`                                               |
 | `--format esm\|cjs\|both`             | Override `output.format`                                            |
-| `--declaration`                       | Override `output.declaration`                                       |
+| `--declaration`                       | Override `output.declaration` and emit matching `.d.ts` files       |
 | `--source-map`                        | Override `output.sourceMap`                                         |
 | `--cache`, `--no-cache`               | Enable or disable on-disk IR caching                                |
 | `--debug`                             | Enable debug logging                                                |
@@ -2312,18 +2312,18 @@ This page describes the TypeScript shapes tywrap generates and returns today.
 
 ### Special Names
 
-| Python                    | TypeScript         |
-| ------------------------- | ------------------ |
-| `Any`                     | `unknown`          |
-| `Never`, `NoReturn`       | `never`            |
-| `LiteralString`, `AnyStr` | `string`           |
-| `object`                  | `object`           |
-| `Awaitable`               | `Promise<unknown>` |
-| `Coroutine`               | `Promise<unknown>` |
-| `TypeVar('T')`            | `unknown`          |
-| `ParamSpec('P')`          | `unknown`          |
-| `TypeVarTuple('Ts')`      | `unknown`          |
-| `Unpack[Ts]`              | `unknown`          |
+| Python                    | TypeScript         | Notes |
+| ------------------------- | ------------------ | ----- |
+| `Any`                     | `unknown`          |       |
+| `Never`, `NoReturn`       | `never`            |       |
+| `LiteralString`, `AnyStr` | `string`           |       |
+| `object`                  | `object`           |       |
+| `Awaitable`               | `Promise<unknown>` |       |
+| `Coroutine`               | `Promise<unknown>` |       |
+| `TypeVar('T')`            | `T`                | Preserved for simple unconstrained/invariant declarations; otherwise falls back to `unknown` |
+| `ParamSpec('P')`          | `P extends unknown[]` | Preserved for callable parameter packs when tywrap can emit a matching generic declaration |
+| `TypeVarTuple('Ts')`      | `unknown`          | Variadic generic parameters still fall back conservatively |
+| `Unpack[Ts]`              | `unknown`          | Variadic tuple unpacking still falls back conservatively |
 
 ## Preset Mappings
 
@@ -2401,16 +2401,51 @@ interface SklearnEstimator {
 ## Limits and Fallbacks
 
 - tywrap does not preserve Python numeric distinctions beyond `number`.
+- tywrap preserves simple unconstrained `TypeVar`s, generic classes, generic
+  type aliases, and callable `ParamSpec` packs in generated `.ts` and `.d.ts`
+  output when they can be rendered safely.
 - Complex user-defined generics that are not explicitly normalized stay as
   custom TypeScript names.
-- Python typing placeholders such as `TypeVar`, `ParamSpec`, `TypeVarTuple`,
-  and `Unpack` are lowered to `unknown`-based shapes because generated wrappers
-  do not currently emit matching TypeScript generic parameters.
+- Bound, constrained, or variant `TypeVar`s, plus variadic generics such as
+  `TypeVarTuple` and `Unpack`, still lower conservatively to `unknown`-based
+  shapes.
+- `P.args` and `P.kwargs` lower conservatively in runtime wrapper signatures as
+  `unknown[]` and `Record<string, unknown>`.
 - `Annotated[...]` metadata is not reflected in the generated type.
 - Runtime serialization can still shape values more narrowly than the static
   annotation alone. `torch.Tensor` and `sklearn` values are examples of this.
 
-## Example
+## Generic Example
+
+```python
+from typing import Callable, Generic, TypeVar
+try:
+    from typing import ParamSpec
+except ImportError:
+    from typing_extensions import ParamSpec
+
+T = TypeVar("T")
+P = ParamSpec("P")
+
+Pair = tuple[T, T]
+Transform = Callable[P, T]
+
+class Container(Generic[T]):
+    def get(self) -> T:
+        ...
+```
+
+Generates TypeScript shaped like:
+
+```ts
+export type Pair<T> = [T, T];
+export type Transform<P extends unknown[], T> = (...args: P) => T;
+export class Container<T> {
+  get(): Promise<T>;
+}
+```
+
+## Basic Example
 
 ```python
 from typing import Literal, Optional, Sequence
@@ -2486,6 +2521,11 @@ await generate({
 
 `runOptions.check` switches generation into compare-only mode, the same behavior
 used by `tywrap generate --check`.
+
+When `output.declaration` is enabled, `generate()` writes matching
+`.generated.d.ts` files from the same generic-aware pass as the runtime wrapper
+code. Simple `TypeVar` and callable `ParamSpec` declarations are preserved when
+tywrap can represent them safely.
 
 ### `tywrap(options?)`
 

--- a/docs/reference/api/index.md
+++ b/docs/reference/api/index.md
@@ -54,6 +54,11 @@ await generate({
 `runOptions.check` switches generation into compare-only mode, the same behavior
 used by `tywrap generate --check`.
 
+When `output.declaration` is enabled, `generate()` writes matching
+`.generated.d.ts` files from the same generic-aware pass as the runtime wrapper
+code. Simple `TypeVar` and callable `ParamSpec` declarations are preserved when
+tywrap can represent them safely.
+
 ### `tywrap(options?)`
 
 Creates the lower-level mapper and generator objects for advanced use.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -68,7 +68,7 @@ npx tywrap generate --modules math,statistics --runtime node
 | `--python`                            | Python executable path override                                     |
 | `--output-dir`                        | Override `output.dir`                                               |
 | `--format esm\|cjs\|both`             | Override `output.format`                                            |
-| `--declaration`                       | Override `output.declaration`                                       |
+| `--declaration`                       | Override `output.declaration` and emit matching `.d.ts` files       |
 | `--source-map`                        | Override `output.sourceMap`                                         |
 | `--cache`, `--no-cache`               | Enable or disable on-disk IR caching                                |
 | `--debug`                             | Enable debug logging                                                |

--- a/docs/reference/type-mapping.md
+++ b/docs/reference/type-mapping.md
@@ -54,18 +54,18 @@ This page describes the TypeScript shapes tywrap generates and returns today.
 
 ### Special Names
 
-| Python                    | TypeScript         |
-| ------------------------- | ------------------ |
-| `Any`                     | `unknown`          |
-| `Never`, `NoReturn`       | `never`            |
-| `LiteralString`, `AnyStr` | `string`           |
-| `object`                  | `object`           |
-| `Awaitable`               | `Promise<unknown>` |
-| `Coroutine`               | `Promise<unknown>` |
-| `TypeVar('T')`            | `unknown`          |
-| `ParamSpec('P')`          | `unknown`          |
-| `TypeVarTuple('Ts')`      | `unknown`          |
-| `Unpack[Ts]`              | `unknown`          |
+| Python                    | TypeScript         | Notes |
+| ------------------------- | ------------------ | ----- |
+| `Any`                     | `unknown`          |       |
+| `Never`, `NoReturn`       | `never`            |       |
+| `LiteralString`, `AnyStr` | `string`           |       |
+| `object`                  | `object`           |       |
+| `Awaitable`               | `Promise<unknown>` |       |
+| `Coroutine`               | `Promise<unknown>` |       |
+| `TypeVar('T')`            | `T`                | Preserved for simple unconstrained/invariant declarations; otherwise falls back to `unknown` |
+| `ParamSpec('P')`          | `P extends unknown[]` | Preserved for callable parameter packs when tywrap can emit a matching generic declaration |
+| `TypeVarTuple('Ts')`      | `unknown`          | Variadic generic parameters still fall back conservatively |
+| `Unpack[Ts]`              | `unknown`          | Variadic tuple unpacking still falls back conservatively |
 
 ## Preset Mappings
 
@@ -143,16 +143,51 @@ interface SklearnEstimator {
 ## Limits and Fallbacks
 
 - tywrap does not preserve Python numeric distinctions beyond `number`.
+- tywrap preserves simple unconstrained `TypeVar`s, generic classes, generic
+  type aliases, and callable `ParamSpec` packs in generated `.ts` and `.d.ts`
+  output when they can be rendered safely.
 - Complex user-defined generics that are not explicitly normalized stay as
   custom TypeScript names.
-- Python typing placeholders such as `TypeVar`, `ParamSpec`, `TypeVarTuple`,
-  and `Unpack` are lowered to `unknown`-based shapes because generated wrappers
-  do not currently emit matching TypeScript generic parameters.
+- Bound, constrained, or variant `TypeVar`s, plus variadic generics such as
+  `TypeVarTuple` and `Unpack`, still lower conservatively to `unknown`-based
+  shapes.
+- `P.args` and `P.kwargs` lower conservatively in runtime wrapper signatures as
+  `unknown[]` and `Record<string, unknown>`.
 - `Annotated[...]` metadata is not reflected in the generated type.
 - Runtime serialization can still shape values more narrowly than the static
   annotation alone. `torch.Tensor` and `sklearn` values are examples of this.
 
-## Example
+## Generic Example
+
+```python
+from typing import Callable, Generic, TypeVar
+try:
+    from typing import ParamSpec
+except ImportError:
+    from typing_extensions import ParamSpec
+
+T = TypeVar("T")
+P = ParamSpec("P")
+
+Pair = tuple[T, T]
+Transform = Callable[P, T]
+
+class Container(Generic[T]):
+    def get(self) -> T:
+        ...
+```
+
+Generates TypeScript shaped like:
+
+```ts
+export type Pair<T> = [T, T];
+export type Transform<P extends unknown[], T> = (...args: P) => T;
+export class Container<T> {
+  get(): Promise<T>;
+}
+```
+
+## Basic Example
 
 ```python
 from typing import Literal, Optional, Sequence

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,18 +1,59 @@
 # Release
 
-## Creating a Release
+## tywrap (npm)
 
-1. Ensure working tree is clean on main branch
+1. Ensure the working tree is clean and `main` is up to date.
 
-2. Bump version and tag:
+2. Check the release-please branch or PR for the next npm release. Verify:
+   - `package.json`
+   - `package-lock.json`
+   - `src/index.ts`
+   - `CHANGELOG.md`
+
+3. Run the release gate in CI-style mode:
+   ```sh
+   CI=1 npm run check:all
+   ```
+
+4. Merge the release-please branch or PR to `main`. The [`release.yml`](../.github/workflows/release.yml)
+   workflow creates the npm tag and publishes the package.
+
+5. If release-please is unavailable, use the manual fallback:
    ```sh
    node scripts/release.mjs <version> --commit --tag
-   ```
-
-3. Push:
-   ```sh
    git push && git push --tags
    ```
+
+## tywrap-ir (PyPI)
+
+1. Bump both exported package-version references:
+   - `tywrap_ir/pyproject.toml`
+   - `tywrap_ir/tywrap_ir/__init__.py`
+
+2. Keep `IR_VERSION` in `tywrap_ir/tywrap_ir/__init__.py` aligned with the
+   current IR schema used by `src/tywrap.ts`.
+
+3. Validate the Python package:
+   ```sh
+   python -m venv .venv-release
+   ./.venv-release/bin/python -m pip install -e tywrap_ir
+   PATH="$PWD/.venv-release/bin:$PATH" python -m unittest discover -s tywrap_ir/tests -p 'test_*.py' -v
+   ```
+
+4. Tag the merged `main` commit and push the tag:
+   ```sh
+   git tag tywrap-ir-v<version>
+   git push origin tywrap-ir-v<version>
+   ```
+
+5. The [`publish-pypi.yml`](../.github/workflows/publish-pypi.yml) workflow
+   publishes `tywrap-ir` to PyPI from that tag.
+
+## Notes
+
+- `tywrap` and `tywrap-ir` are versioned independently.
+- `tywrap` release tags use `vX.Y.Z`.
+- `tywrap-ir` release tags use `tywrap-ir-vX.Y.Z`.
 
 ## Version Format
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tywrap",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tywrap",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.25.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tywrap",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Generate type-safe TypeScript wrappers for any Python library — Node.js, Deno, Bun, and browsers via Pyodide.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,7 +147,7 @@ export {
 } from './utils/codec.js';
 
 // Version info
-export const VERSION = '0.2.1';
+export const VERSION = '0.3.0';
 
 /**
  * Quick setup function for getting started

--- a/src/runtime/node.ts
+++ b/src/runtime/node.ts
@@ -349,10 +349,7 @@ export class NodeBridge extends BridgeProtocol {
       resolvedOptions.warmupCommands.length > 0
         ? createWarmupCallback(resolvedOptions.warmupCommands, resolvedOptions.timeoutMs)
         : undefined;
-    const replacementWorkerReady = createWorkerReadyCallback(
-      resolvedOptions.timeoutMs,
-      userWarmup
-    );
+    const replacementWorkerReady = createWorkerReadyCallback(resolvedOptions.timeoutMs, userWarmup);
 
     // Create pooled transport with ProcessIO workers
     const transport = new PooledTransport({

--- a/src/runtime/pooled-transport.ts
+++ b/src/runtime/pooled-transport.ts
@@ -83,7 +83,10 @@ export interface PooledTransportOptions {
  * ```
  */
 export class PooledTransport extends BoundedContext implements Transport {
-  private readonly poolOptions: Omit<Required<PooledTransportOptions>, 'onWorkerReady' | 'onReplacementWorkerReady'> & {
+  private readonly poolOptions: Omit<
+    Required<PooledTransportOptions>,
+    'onWorkerReady' | 'onReplacementWorkerReady'
+  > & {
     onWorkerReady?: (worker: PooledWorker) => Promise<void>;
     onReplacementWorkerReady?: (worker: PooledWorker) => Promise<void>;
   };

--- a/src/runtime/worker-pool.ts
+++ b/src/runtime/worker-pool.ts
@@ -106,7 +106,10 @@ interface QueuedWaiter {
  * ```
  */
 export class WorkerPool extends BoundedContext {
-  private readonly options: Omit<Required<WorkerPoolOptions>, 'onWorkerReady' | 'onReplacementWorkerReady'> & {
+  private readonly options: Omit<
+    Required<WorkerPoolOptions>,
+    'onWorkerReady' | 'onReplacementWorkerReady'
+  > & {
     onWorkerReady?: (worker: PooledWorker) => Promise<void>;
     onReplacementWorkerReady?: (worker: PooledWorker) => Promise<void>;
   };
@@ -435,9 +438,7 @@ export class WorkerPool extends BoundedContext {
    * If onWorkerReady is configured, calls it after the transport is initialized.
    * This is useful for per-worker warmup (importing modules, running setup).
    */
-  private async createWorker(
-    onWorkerReady = this.options.onWorkerReady
-  ): Promise<PooledWorker> {
+  private async createWorker(onWorkerReady = this.options.onWorkerReady): Promise<PooledWorker> {
     const transport = this.options.createTransport();
 
     // Initialize the transport

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -377,9 +377,7 @@ describe('CLI', () => {
       }
     });
 
-    it(
-      'accepts --format flag with valid values',
-      () => {
+    it('accepts --format flag with valid values', () => {
       const tempDir = mkdtempSync(join(tmpdir(), 'tywrap-cli-'));
       try {
         for (const format of ['esm', 'cjs', 'both']) {
@@ -398,9 +396,7 @@ describe('CLI', () => {
       } finally {
         rmSync(tempDir, { recursive: true, force: true });
       }
-      },
-      15000
-    );
+    }, 15000);
 
     it('rejects --format flag with invalid value', () => {
       const tempDir = mkdtempSync(join(tmpdir(), 'tywrap-cli-'));
@@ -523,9 +519,7 @@ describe('CLI', () => {
       }
     });
 
-    it(
-      'supports --check without writing files',
-      () => {
+    it('supports --check without writing files', () => {
       const repoRoot = join(__dirname, '..');
       const tempDir = mkdtempSync(join(tmpdir(), 'tywrap-cli-'));
       const outputDir = join(tempDir, 'generated');
@@ -581,9 +575,7 @@ describe('CLI', () => {
       } finally {
         rmSync(tempDir, { recursive: true, force: true });
       }
-      },
-      15000
-    );
+    }, 15000);
 
     it('fails with actionable errors when a module cannot be imported', () => {
       const repoRoot = join(__dirname, '..');

--- a/test/runtime_node.test.ts
+++ b/test/runtime_node.test.ts
@@ -1278,7 +1278,6 @@ def get_bad():
       },
       testTimeout
     );
-
   });
 
   describe('Performance Characteristics', () => {

--- a/tywrap_ir/README.md
+++ b/tywrap_ir/README.md
@@ -12,6 +12,10 @@ Python IR extractor for [tywrap](https://github.com/bbopen/tywrap). Emits versio
 pip install tywrap-ir
 ```
 
+`tywrap-ir` is versioned independently from the `tywrap` npm package. Install
+the latest published release of each package unless you need to pin them
+explicitly.
+
 ## Usage
 
 ```bash

--- a/tywrap_ir/pyproject.toml
+++ b/tywrap_ir/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tywrap-ir"
-version = "0.2.0"
+version = "0.2.1"
 description = "Python IR extractor for tywrap: emits versioned JSON IR for Python modules"
 readme = "README.md"
 authors = [

--- a/tywrap_ir/tywrap_ir/__init__.py
+++ b/tywrap_ir/tywrap_ir/__init__.py
@@ -4,7 +4,7 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "0.2.0"
-IR_VERSION = "0.1.0"
+__version__ = "0.2.1"
+IR_VERSION = "0.2.0"
 
 from .ir import extract_module_ir  # noqa: E402


### PR DESCRIPTION
## Summary

Prepare the next release from the current post-`v0.2.1` state on `main`.

This branch builds on the existing `release-please` `0.3.0` bump and patches the release artifacts so they match the code that will actually ship.

## What changed

- correct the npm release notes to include PR `#210` (`Safe TypeScript generic emission`)
- update the exported `tywrap` runtime version constant to `0.3.0`
- bump `tywrap-ir` package metadata from `0.2.0` to `0.2.1`
- align `tywrap_ir.__version__` and `IR_VERSION` with the current Python IR schema in use
- update install/release documentation to reflect split npm/PyPI versioning
- update docs to describe the generic-aware declaration output added since `v0.2.1`
- regenerate `docs/public/llms-full.txt`
- include the minimal Prettier cleanup needed for the release gate to pass

## Why

The autogenerated release branch was incomplete for this release:

- the generated changelog omitted the most important product-facing change in `#210`
- `src/index.ts` still exported `0.2.1`
- Python package version exports were internally inconsistent (`__version__` still `0.2.0`, `IR_VERSION` still `0.1.0`)
- the release docs no longer matched the actual repo workflow now that npm and PyPI releases are handled separately
- the type-mapping docs still described the pre-`#210` generic fallback behavior

Without these fixes, the published version metadata and release notes would not accurately describe the shipped code.

## User impact

- npm consumers get a coherent `tywrap@0.3.0` release with matching version exports and release notes
- PyPI consumers can receive a matching `tywrap-ir@0.2.1` tag/publish after merge
- docs now accurately describe installation, split package versioning, and the generic-aware `.d.ts` output available in this release

## Validation

- `CI=1 PATH="$PWD/.venv-release/bin:$PATH" npm run check:all`
- `PATH="$PWD/.venv-release/bin:$PATH" python -m unittest discover -s tywrap_ir/tests -p 'test_*.py' -v`
- `CI=1 PATH="$PWD/.venv-release/bin:$PATH" npm run docs:build`

## Release note

Merging this PR should trigger the normal PR CI immediately. The npm release workflow still runs only after merge to `main`. The PyPI release still requires tagging the merged main commit with `tywrap-ir-v0.2.1`.