### PR TITLE
docs(runtime): clarify NodeBridge public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,13 @@ const bridge = new NodeBridge({
 });
 ```
 
-NodeBridge is the default, correctness-first bridge. OptimizedNodeBridge is a
-performance-focused prototype (process pooling + optional caching) and is not a
-drop-in replacement yet. See `ROADMAP.md` for the unification plan.
+NodeBridge is the public Node runtime bridge. It runs in single-process mode by
+default and also supports pooled execution through `minProcesses`,
+`maxProcesses`, and `maxConcurrentPerProcess`.
+
+`OptimizedNodeBridge` is now only a deprecated compatibility alias for older
+deep imports. It is not part of the package exports and should not be used in
+new code.
 
 Both bridges share a common JSONL core for protocol validation and timeouts.
 

--- a/docs/guide/runtimes/node.md
+++ b/docs/guide/runtimes/node.md
@@ -17,11 +17,12 @@ The Node.js runtime:
 
 ## Bridge Selection
 
-- **NodeBridge (default)**: correctness-first, simplest lifecycle, recommended
-  for most users.
-- **OptimizedNodeBridge (experimental)**: process pooling + optional caching for
-  throughput; not a drop-in replacement yet and not part of the public API
-  exports. See `ROADMAP.md` for the unification plan and parity goals.
+- **NodeBridge (default)**: the public Node bridge. It supports both
+  single-process execution and pooled execution through its constructor
+  options.
+- **OptimizedNodeBridge**: deprecated compatibility alias for older deep
+  imports. It is not part of the package exports and should not be used in new
+  code.
 
 Both bridges share the same JSONL core for protocol validation, timeouts, and
 stderr buffering.

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -1080,11 +1080,12 @@ The Node.js runtime:
 
 ## Bridge Selection
 
-- **NodeBridge (default)**: correctness-first, simplest lifecycle, recommended
-  for most users.
-- **OptimizedNodeBridge (experimental)**: process pooling + optional caching for
-  throughput; not a drop-in replacement yet and not part of the public API
-  exports. See `ROADMAP.md` for the unification plan and parity goals.
+- **NodeBridge (default)**: the public Node bridge. It supports both
+  single-process execution and pooled execution through its constructor
+  options.
+- **OptimizedNodeBridge**: deprecated compatibility alias for older deep
+  imports. It is not part of the package exports and should not be used in new
+  code.
 
 Both bridges share the same JSONL core for protocol validation, timeouts, and
 stderr buffering.

--- a/src/runtime/optimized-node.ts
+++ b/src/runtime/optimized-node.ts
@@ -1,9 +1,9 @@
 /**
  * @deprecated Import from './node.js' instead.
  *
- * OptimizedNodeBridge has been unified with NodeBridge. The NodeBridge class
- * now supports both single-process mode (default) and multi-process pooling
- * via the minProcesses/maxProcesses options.
+ * Backward-compat shim for older deep imports. NodeBridge is the public API,
+ * and it now supports both single-process mode (default) and multi-process
+ * pooling via the minProcesses/maxProcesses options.
  *
  * Migration:
  * ```typescript
@@ -16,7 +16,8 @@
  * const bridge = new NodeBridge({ minProcesses: 2, maxProcesses: 4 });
  * ```
  *
- * This file is maintained for backward compatibility only.
+ * This file is not exposed through the package exports map and is maintained
+ * for backward compatibility only.
  */
 export {
   NodeBridge as OptimizedNodeBridge,


### PR DESCRIPTION
## Summary
- update the README and Node runtime guide to describe `NodeBridge` as the public Node bridge
- explain that pooled execution is configured on `NodeBridge` instead of treated as a separate product path
- clarify that `OptimizedNodeBridge` is only a deprecated compatibility alias for older deep imports and regenerate `docs/public/llms-full.txt`

## Validation
- `node scripts/generate-llms-full.mjs`
- `git diff --check`

## Notes
- I did not run `npm`-based checks in this worktree because dependencies are not installed (`tsc` and `vitest` are unavailable).