### PR TITLE
[codex] fix v0.4.0 release publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 22
           cache: npm
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 24]
+        node-version: [20, 22]
         python-version: ['3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v6
@@ -68,11 +68,11 @@ jobs:
         env:
           NODE_OPTIONS: --expose-gc
           TYWRAP_PERF_BUDGETS: '1'
-        run: ${{ (matrix.node-version == 24 && matrix.python-version == '3.11') && 'npm run test:coverage' || 'npm test' }}
+        run: ${{ (matrix.node-version == 22 && matrix.python-version == '3.11') && 'npm run test:coverage' || 'npm test' }}
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
-        if: matrix.node-version == 24 && matrix.python-version == '3.11'
+        if: matrix.node-version == 22 && matrix.python-version == '3.11'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
@@ -124,7 +124,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 22
           cache: npm
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -179,7 +179,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 22
           cache: npm
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -209,7 +209,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 22
           cache: npm
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -239,7 +239,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 22
           cache: npm
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 22
           cache: npm
 
       - uses: actions/configure-pages@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,7 +172,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 22
           cache: npm
 
       - name: Skip if version is already published
@@ -211,6 +211,12 @@ jobs:
         env:
           NODE_OPTIONS: --expose-gc
           TYWRAP_PERF_BUDGETS: '1'
+
+      - name: Switch to Node 24 for npm trusted publishing
+        if: ${{ steps.npm_registry.outputs.already_published != 'true' }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
 
       - name: Publish to npm
         if: ${{ steps.npm_registry.outputs.already_published != 'true' }}

--- a/docs/release.md
+++ b/docs/release.md
@@ -23,8 +23,8 @@
 5. npm publishing uses npm trusted publishing from GitHub Actions. Keep the npm
    package connected to this repository as a trusted publisher, and do not add a
    publish token to the workflow for the normal release path. The release job
-   validates the tagged package on Node 24 and publishes with
-   `npm publish --provenance` from that same runtime.
+   validates the tagged package on Node 22, then switches to Node 24 for the
+   final `npm publish --provenance` step so npm uses an OIDC-capable CLI.
 
 6. For the normal `release-please` path, keep the repository Actions setting
    `Allow GitHub Actions to create and approve pull requests` enabled.


### PR DESCRIPTION
This fixes the `v0.4.0` release blocker introduced by moving the workflow install and validation baseline to Node 24.

The failure was not in Tywrap's TypeScript or release logic. It happened earlier during `npm ci`, when the `tree-sitter` native addon rebuilt under Node 24 on GitHub Actions and failed because that build path needs an explicit C++20 compiler mode. The `Release Please` workflow successfully created the `v0.4.0` tag and GitHub release, but the npm publish job stopped before build, test, or publish.

This change restores the previous known-good workflow split. CI, docs, and release validation run on Node 22 again, and the release workflow switches to Node 24 only for the final trusted `npm publish --provenance` step. That keeps the npm publishing path compliant without forcing the native addon rebuild through the unsupported Node 24 validation path.

This is intentionally narrow. It does not change the `v0.4.0` package contents, changelog, or dependency set. It only unblocks the existing release tag.

Validation:
- `git diff --check`
- reviewed the failed `Release Please` run `24320199817`
- confirmed the failure occurs in `publish_npm` during `npm ci`, before Tywrap build/tests
