### PR TITLE
0.6.1: maintenance — decompose complexity hotspots, dedup dispatch, drop dead exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.6.1](https://github.com/bbopen/tywrap/compare/v0.6.0...v0.6.1) (2026-05-31)
+
+A maintenance release. Nothing you call changes — no API, behavior, or wire-protocol changes.
+
+Internal cleanup only: removed two dead exports, broke the eleven worst complexity hotspots into smaller helpers with their output unchanged (cache-key generation, type-hint validation, the dev watch/reload paths, the subprocess write queue, module discovery, path and interpreter resolution, and an annotation-parser helper), and factored the duplicated request/response dispatch in the codec and RPC client into one path. The static-analysis actionable-complexity count dropped from 14 to 3 — the remaining three are deferred to 0.7.0 or left as-is on purpose.
+
 ## [0.6.0](https://github.com/bbopen/tywrap/compare/v0.5.1...v0.6.0) (2026-05-31)
 
 A cleanup release. There are no new features — this is one breaking pass that renames much of the runtime vocabulary, trims the public API, and tightens a couple of defaults, so the churn happens once instead of dribbling across several releases. If you only use the high-level `tywrap()`, `generate()`, and `defineConfig()` API, most of this won't touch you. The wire protocol is unchanged, so a 0.5.x client and a 0.6.0 bridge still talk to each other.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tywrap",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Generate type-safe TypeScript wrappers for any Python library — Node.js, Deno, Bun, and browsers via Pyodide.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/core/annotation-parser.ts
+++ b/src/core/annotation-parser.ts
@@ -118,30 +118,35 @@ export function parseAnnotationToPythonType(
     return { kind: 'custom', name: n };
   };
 
+  // Extracts the leading quoted string from the body of a `Name(...)` factory call
+  // (the `inner` already stripped of the outer `Name(` and trailing `)`). Returns
+  // the unquoted name, or null when the body is not a well-formed quoted argument.
+  const extractQuotedFactoryArg = (inner: string): string | null => {
+    if (inner.length < 2) {
+      return null;
+    }
+
+    const quote = inner[0];
+    if ((quote !== "'" && quote !== '"') || inner[inner.length - 1] !== quote) {
+      return null;
+    }
+
+    const commaIndex = inner.indexOf(',');
+    const quoted = commaIndex === -1 ? inner : inner.slice(0, commaIndex).trimEnd();
+    if (quoted.length < 2 || quoted[quoted.length - 1] !== quote) {
+      return null;
+    }
+
+    return quoted.slice(1, -1);
+  };
+
   const parseTypingFactoryName = (text: string, name: string): string | null => {
     for (const prefix of modulePrefixes) {
       const start = `${prefix}${name}(`;
       if (!text.startsWith(start) || !text.endsWith(')')) {
         continue;
       }
-
-      const inner = text.slice(start.length, -1).trim();
-      if (inner.length < 2) {
-        return null;
-      }
-
-      const quote = inner[0];
-      if ((quote !== "'" && quote !== '"') || inner[inner.length - 1] !== quote) {
-        return null;
-      }
-
-      const commaIndex = inner.indexOf(',');
-      const quoted = commaIndex === -1 ? inner : inner.slice(0, commaIndex).trimEnd();
-      if (quoted.length < 2 || quoted[quoted.length - 1] !== quote) {
-        return null;
-      }
-
-      return quoted.slice(1, -1);
+      return extractQuotedFactoryArg(text.slice(start.length, -1).trim());
     }
 
     return null;

--- a/src/core/discovery.ts
+++ b/src/core/discovery.ts
@@ -122,38 +122,61 @@ export class ModuleDiscovery {
       return cached.path;
     }
 
-    // Try to resolve using Python's module finder
-    if (processUtils.isAvailable()) {
-      try {
-        const pythonPath = await this.getPythonExecutable();
-        const result = await processUtils.exec(
-          pythonPath,
-          [
-            '-c',
-            `import ${moduleName}; print(${moduleName}.__file__ if hasattr(${moduleName}, '__file__') else '${moduleName}.__path__[0]' if hasattr(${moduleName}, '__path__') else 'builtin')`,
-          ],
-          { timeoutMs: this.options.timeoutMs }
-        );
+    // Try to resolve using Python's module finder, then fall back to a
+    // filesystem search across the known Python paths.
+    return (
+      (await this.resolveViaInterpreter(moduleName)) ??
+      (await this.resolveViaSearchPaths(moduleName))
+    );
+  }
 
-        if (result.code === 0 && result.stdout.trim() !== 'builtin') {
-          const modulePath = result.stdout.trim();
-
-          // Cache the result
-          this.moduleCache.set(moduleName, {
-            name: moduleName,
-            path: modulePath,
-            isPackage: modulePath.endsWith('__init__.py'),
-            dependencies: [],
-          });
-
-          return modulePath;
-        }
-      } catch (error) {
-        log.warn('Failed to resolve module', { moduleName, error: String(error) });
-      }
+  /**
+   * Resolve a module path by asking the Python interpreter for `__file__`.
+   * Caches and returns the resolved path, or `null` when the interpreter is
+   * unavailable, reports a builtin, or fails.
+   */
+  private async resolveViaInterpreter(moduleName: string): Promise<string | null> {
+    if (!processUtils.isAvailable()) {
+      return null;
     }
 
-    // Fallback: search in known Python paths
+    try {
+      const pythonPath = await this.getPythonExecutable();
+      const result = await processUtils.exec(
+        pythonPath,
+        [
+          '-c',
+          `import ${moduleName}; print(${moduleName}.__file__ if hasattr(${moduleName}, '__file__') else '${moduleName}.__path__[0]' if hasattr(${moduleName}, '__path__') else 'builtin')`,
+        ],
+        { timeoutMs: this.options.timeoutMs }
+      );
+
+      if (result.code === 0 && result.stdout.trim() !== 'builtin') {
+        const modulePath = result.stdout.trim();
+
+        // Cache the result
+        this.moduleCache.set(moduleName, {
+          name: moduleName,
+          path: modulePath,
+          isPackage: modulePath.endsWith('__init__.py'),
+          dependencies: [],
+        });
+
+        return modulePath;
+      }
+    } catch (error) {
+      log.warn('Failed to resolve module', { moduleName, error: String(error) });
+    }
+
+    return null;
+  }
+
+  /**
+   * Fallback resolution: probe `<path>/<module>.py` and
+   * `<path>/<module>/__init__.py` across the known Python search paths.
+   * Returns the first existing candidate, or `null`.
+   */
+  private async resolveViaSearchPaths(moduleName: string): Promise<string | null> {
     const searchPaths = await this.getPythonSearchPaths();
 
     for (const searchPath of searchPaths) {
@@ -237,40 +260,33 @@ export class ModuleDiscovery {
    */
   parseDependenciesFromSource(source: string): string[] {
     const dependencies: string[] = [];
-    const lines = source.split('\n');
 
-    for (const line of lines) {
-      const trimmed = line.trim();
-
-      // Skip comments and empty lines
-      if (trimmed.startsWith('#') || trimmed === '') {
-        continue;
-      }
-
-      // Match import statements
-      const importMatch = trimmed.match(/^import\s+([a-zA-Z_][a-zA-Z0-9_\.]*)/);
-      if (importMatch?.[1]) {
-        const fullModuleName = importMatch[1];
-        const moduleName = fullModuleName.split('.')[0]; // Get top-level module
-        if (moduleName) {
-          dependencies.push(moduleName);
-        }
-        continue;
-      }
-
-      // Match from ... import statements
-      const fromMatch = trimmed.match(/^from\s+([a-zA-Z_][a-zA-Z0-9_\.]*)\s+import/);
-      if (fromMatch?.[1]) {
-        const fullModuleName = fromMatch[1];
-        const moduleName = fullModuleName.split('.')[0]; // Get top-level module
-        if (moduleName) {
-          dependencies.push(moduleName);
-        }
-        continue;
+    for (const line of source.split('\n')) {
+      const moduleName = this.extractImportedModule(line.trim());
+      if (moduleName) {
+        dependencies.push(moduleName);
       }
     }
 
     return [...new Set(dependencies)]; // Remove duplicates
+  }
+
+  /**
+   * Extract the top-level module name imported by a single (trimmed) source
+   * line, or `null` when the line is a comment, blank, or not an import.
+   */
+  private extractImportedModule(trimmed: string): string | null {
+    // Skip comments and empty lines
+    if (trimmed.startsWith('#') || trimmed === '') {
+      return null;
+    }
+
+    // Match `import x.y.z` and `from x.y.z import ...` statements.
+    const match =
+      trimmed.match(/^import\s+([a-zA-Z_][a-zA-Z0-9_\.]*)/) ??
+      trimmed.match(/^from\s+([a-zA-Z_][a-zA-Z0-9_\.]*)\s+import/);
+
+    return match?.[1]?.split('.')[0] ?? null; // Get top-level module
   }
 
   /**

--- a/src/core/validation.ts
+++ b/src/core/validation.ts
@@ -195,60 +195,96 @@ export class ValidationEngine {
     errors: AnalysisError[],
     warnings: AnalysisWarning[]
   ): void {
-    // Check return type (skip __init__ methods as they conventionally don't need return type annotations)
-    if (this.isEmptyType(func.returnType) && func.name !== '__init__') {
-      if (this.config.allowMissingTypeHints) {
-        warnings.push({
-          type: 'missing-type',
-          message: `Function '${func.name}' is missing return type annotation`,
-        });
-      } else if (this.config.strictTypeChecking) {
-        // In strict mode without allowMissingTypeHints, we warn first then error
-        warnings.push({
-          type: 'missing-type',
-          message: `Function '${func.name}' is missing return type annotation`,
-        });
-        errors.push({
-          type: 'type',
-          message: `Function '${func.name}' requires return type annotation`,
-        });
-      }
-    }
+    this.checkReturnTypeHint(func, errors, warnings);
 
     // Check parameter types (skip 'self' and 'cls' parameters)
     for (const param of func.parameters) {
-      if (this.isEmptyType(param.type) && param.name !== 'self' && param.name !== 'cls') {
-        if (this.config.allowMissingTypeHints) {
-          warnings.push({
-            type: 'missing-type',
-            message: `Parameter '${param.name}' in function '${func.name}' is missing type annotation`,
-          });
-        } else if (this.config.strictTypeChecking) {
-          // In strict mode without allowMissingTypeHints, we warn first then error
-          warnings.push({
-            type: 'missing-type',
-            message: `Parameter '${param.name}' in function '${func.name}' is missing type annotation`,
-          });
-          errors.push({
-            type: 'type',
-            message: `Parameter '${param.name}' in function '${func.name}' requires type annotation`,
-          });
-        }
-      }
-
-      // Validate type structure only in strict mode (skip 'self' and 'cls' parameters)
-      if (
-        this.config.strictTypeChecking &&
-        !this.config.allowMissingTypeHints &&
-        param.name !== 'self' &&
-        param.name !== 'cls'
-      ) {
-        const typeErrors = this.validateTypeAnnotation(param.type, `parameter '${param.name}'`);
-        errors.push(...typeErrors);
-      }
+      this.checkParameterTypeHint(func, param, errors, warnings);
+      this.checkParameterTypeStructure(param, errors);
     }
 
-    // Validate return type structure only in strict mode
+    this.checkReturnTypeStructure(func, errors);
+  }
+
+  /**
+   * Emit a missing-type warning, and—in strict mode—an accompanying error.
+   * In strict mode without allowMissingTypeHints, we warn first then error.
+   */
+  private reportMissingType(
+    warningMessage: string,
+    errorMessage: string,
+    warnings: AnalysisWarning[],
+    errors: AnalysisError[]
+  ): void {
+    if (this.config.allowMissingTypeHints) {
+      warnings.push({ type: 'missing-type', message: warningMessage });
+    } else if (this.config.strictTypeChecking) {
+      warnings.push({ type: 'missing-type', message: warningMessage });
+      errors.push({ type: 'type', message: errorMessage });
+    }
+  }
+
+  /**
+   * Check the function return type annotation (skip __init__ methods as they
+   * conventionally don't need return type annotations).
+   */
+  private checkReturnTypeHint(
+    func: PythonFunction,
+    errors: AnalysisError[],
+    warnings: AnalysisWarning[]
+  ): void {
+    if (this.isEmptyType(func.returnType) && func.name !== '__init__') {
+      this.reportMissingType(
+        `Function '${func.name}' is missing return type annotation`,
+        `Function '${func.name}' requires return type annotation`,
+        warnings,
+        errors
+      );
+    }
+  }
+
+  /**
+   * Check a single parameter's type annotation (skip 'self' and 'cls').
+   */
+  private checkParameterTypeHint(
+    func: PythonFunction,
+    param: PythonFunction['parameters'][number],
+    errors: AnalysisError[],
+    warnings: AnalysisWarning[]
+  ): void {
+    if (this.isEmptyType(param.type) && param.name !== 'self' && param.name !== 'cls') {
+      this.reportMissingType(
+        `Parameter '${param.name}' in function '${func.name}' is missing type annotation`,
+        `Parameter '${param.name}' in function '${func.name}' requires type annotation`,
+        warnings,
+        errors
+      );
+    }
+  }
+
+  /**
+   * Validate a single parameter's type structure only in strict mode
+   * (skip 'self' and 'cls' parameters).
+   */
+  private checkParameterTypeStructure(
+    param: PythonFunction['parameters'][number],
+    errors: AnalysisError[]
+  ): void {
+    if (
+      this.config.strictTypeChecking &&
+      !this.config.allowMissingTypeHints &&
+      param.name !== 'self' &&
+      param.name !== 'cls'
+    ) {
+      const typeErrors = this.validateTypeAnnotation(param.type, `parameter '${param.name}'`);
+      errors.push(...typeErrors);
+    }
+  }
+
+  /**
+   * Validate the return type structure only in strict mode.
+   */
+  private checkReturnTypeStructure(func: PythonFunction, errors: AnalysisError[]): void {
     if (this.config.strictTypeChecking && !this.config.allowMissingTypeHints) {
       const returnTypeErrors = this.validateTypeAnnotation(func.returnType, 'return type');
       errors.push(...returnTypeErrors);

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -335,42 +335,44 @@ async function listExistingManagedFiles(outputDir: string): Promise<Set<string>>
   return managedFiles;
 }
 
+async function listChildDirectories(current: string): Promise<string[]> {
+  let entries;
+  try {
+    entries = await readdir(current, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  return entries
+    .filter(entry => entry.isDirectory())
+    .map(entry => join(current, entry.name));
+}
+
+async function isWatchableDirectory(current: string, ignoredPaths: string[]): Promise<boolean> {
+  if (shouldIgnoreWatchPath(current, ignoredPaths)) {
+    return false;
+  }
+
+  try {
+    const currentStats = await stat(current);
+    return currentStats.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
 async function collectWatchDirectories(root: string, ignoredPaths: string[]): Promise<string[]> {
   const queue = [resolve(root)];
   const directories: string[] = [];
 
   while (queue.length > 0) {
     const current = queue.shift()!;
-    if (shouldIgnoreWatchPath(current, ignoredPaths)) {
-      continue;
-    }
-
-    let currentStats;
-    try {
-      currentStats = await stat(current);
-    } catch {
-      continue;
-    }
-
-    if (!currentStats.isDirectory()) {
+    if (!(await isWatchableDirectory(current, ignoredPaths))) {
       continue;
     }
 
     directories.push(current);
-
-    let entries;
-    try {
-      entries = await readdir(current, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-
-    for (const entry of entries) {
-      if (!entry.isDirectory()) {
-        continue;
-      }
-      queue.push(join(current, entry.name));
-    }
+    queue.push(...(await listChildDirectories(current)));
   }
 
   return normalizePaths(directories);
@@ -444,7 +446,51 @@ async function promoteManagedFiles(
   }
 }
 
-async function resolveWatchTargets(config: TywrapOptions): Promise<WatchTarget[]> {
+interface WatchTargetPayload {
+  missing?: boolean;
+  origin?: string | null;
+  locations?: string[];
+  has_location?: boolean;
+}
+
+interface WatchPythonEnv {
+  pythonPath: string;
+  env: { PYTHONPATH: string } | undefined;
+  timeoutMs: number;
+}
+
+const WATCH_TARGET_RESOLUTION_SCRIPT = [
+  'import importlib',
+  'import importlib.util',
+  'import json',
+  'import sys',
+  '',
+  'module_name = sys.argv[1]',
+  'spec = importlib.util.find_spec(module_name)',
+  'if spec is None:',
+  "    print(json.dumps({'missing': True}))",
+  '    raise SystemExit(0)',
+  '',
+  'module_path = None',
+  'module_origin = spec.origin',
+  'if spec.submodule_search_locations:',
+  '    try:',
+  '        module = importlib.import_module(module_name)',
+  '    except Exception:',
+  '        module = None',
+  '    if module is not None:',
+  '        module_path = getattr(module, "__path__", None)',
+  '        module_origin = getattr(module, "__file__", None) or spec.origin',
+  'payload = {',
+  "    'missing': False,",
+  "    'origin': module_origin,",
+  "    'locations': list(module_path) if module_path is not None else list(spec.submodule_search_locations or []),",
+  "    'has_location': bool(spec.has_location),",
+  '}',
+  'print(json.dumps(payload))',
+].join('\n');
+
+async function resolveWatchPythonEnv(config: TywrapOptions): Promise<WatchPythonEnv> {
   const pythonPath = await resolvePythonExecutable({
     pythonPath: config.runtime?.node?.pythonPath,
     virtualEnv: config.runtime?.node?.virtualEnv,
@@ -460,104 +506,100 @@ async function resolveWatchTargets(config: TywrapOptions): Promise<WatchTarget[]
   const env = mergedPyPath ? { PYTHONPATH: mergedPyPath } : undefined;
   const timeoutMs = config.runtime?.node?.timeout ?? 30000;
 
+  return { pythonPath, env, timeoutMs };
+}
+
+async function resolveWatchTargetPayload(
+  moduleName: string,
+  pythonEnv: WatchPythonEnv
+): Promise<WatchTargetPayload> {
+  const result = await processUtils.exec(
+    pythonEnv.pythonPath,
+    ['-c', WATCH_TARGET_RESOLUTION_SCRIPT, moduleName],
+    {
+      timeoutMs: pythonEnv.timeoutMs,
+      env: pythonEnv.env,
+    }
+  );
+
+  if (result.code !== 0) {
+    throw new Error(
+      `Failed to resolve watch target for module "${moduleName}": ${result.stderr.trim() || result.stdout.trim() || 'unknown error'}`
+    );
+  }
+
+  try {
+    return JSON.parse(result.stdout) as WatchTargetPayload;
+  } catch (error) {
+    throw new Error(
+      `Failed to parse watch target for module "${moduleName}": ${(error as Error).message}`
+    );
+  }
+}
+
+async function resolvePackageWatchTargets(
+  moduleName: string,
+  packageLocations: string[]
+): Promise<WatchTarget[]> {
+  const targets: WatchTarget[] = [];
+  for (const location of packageLocations) {
+    const packageDir = resolve(location);
+    const stats = await stat(packageDir);
+    if (!stats.isDirectory()) {
+      throw new Error(
+        `Module "${moduleName}" resolved to "${packageDir}", but it is not a package directory`
+      );
+    }
+    targets.push({ moduleName, path: packageDir, kind: 'directory' });
+  }
+  return targets;
+}
+
+async function resolveFileWatchTarget(
+  moduleName: string,
+  payload: WatchTargetPayload
+): Promise<WatchTarget> {
+  if (typeof payload.origin !== 'string' || !payload.origin.endsWith('.py')) {
+    throw new Error(
+      `Module "${moduleName}" is not backed by a local Python source file or package directory and cannot be watched`
+    );
+  }
+
+  const modulePath = resolve(payload.origin);
+  const stats = await stat(modulePath);
+  if (!stats.isFile()) {
+    throw new Error(
+      `Module "${moduleName}" resolved to "${modulePath}", but it is not a Python source file`
+    );
+  }
+
+  return { moduleName, path: modulePath, kind: 'file' };
+}
+
+async function resolveModuleWatchTargets(
+  moduleName: string,
+  pythonEnv: WatchPythonEnv
+): Promise<WatchTarget[]> {
+  const payload = await resolveWatchTargetPayload(moduleName, pythonEnv);
+
+  if (payload.missing) {
+    throw new Error(`Module "${moduleName}" could not be resolved for watching`);
+  }
+
+  const packageLocations = Array.isArray(payload.locations) ? payload.locations : [];
+  if (packageLocations.length > 0) {
+    return resolvePackageWatchTargets(moduleName, packageLocations);
+  }
+
+  return [await resolveFileWatchTarget(moduleName, payload)];
+}
+
+async function resolveWatchTargets(config: TywrapOptions): Promise<WatchTarget[]> {
+  const pythonEnv = await resolveWatchPythonEnv(config);
+
   const watchTargets: WatchTarget[] = [];
-
   for (const moduleName of Object.keys(config.pythonModules ?? {})) {
-    const resolutionScript = [
-      'import importlib',
-      'import importlib.util',
-      'import json',
-      'import sys',
-      '',
-      'module_name = sys.argv[1]',
-      'spec = importlib.util.find_spec(module_name)',
-      'if spec is None:',
-      "    print(json.dumps({'missing': True}))",
-      '    raise SystemExit(0)',
-      '',
-      'module_path = None',
-      'module_origin = spec.origin',
-      'if spec.submodule_search_locations:',
-      '    try:',
-      '        module = importlib.import_module(module_name)',
-      '    except Exception:',
-      '        module = None',
-      '    if module is not None:',
-      '        module_path = getattr(module, "__path__", None)',
-      '        module_origin = getattr(module, "__file__", None) or spec.origin',
-      'payload = {',
-      "    'missing': False,",
-      "    'origin': module_origin,",
-      "    'locations': list(module_path) if module_path is not None else list(spec.submodule_search_locations or []),",
-      "    'has_location': bool(spec.has_location),",
-      '}',
-      'print(json.dumps(payload))',
-    ].join('\n');
-
-    const result = await processUtils.exec(pythonPath, ['-c', resolutionScript, moduleName], {
-      timeoutMs,
-      env,
-    });
-
-    if (result.code !== 0) {
-      throw new Error(
-        `Failed to resolve watch target for module "${moduleName}": ${result.stderr.trim() || result.stdout.trim() || 'unknown error'}`
-      );
-    }
-
-    let payload: {
-      missing?: boolean;
-      origin?: string | null;
-      locations?: string[];
-      has_location?: boolean;
-    };
-    try {
-      payload = JSON.parse(result.stdout) as {
-        missing?: boolean;
-        origin?: string | null;
-        locations?: string[];
-        has_location?: boolean;
-      };
-    } catch (error) {
-      throw new Error(
-        `Failed to parse watch target for module "${moduleName}": ${(error as Error).message}`
-      );
-    }
-
-    if (payload.missing) {
-      throw new Error(`Module "${moduleName}" could not be resolved for watching`);
-    }
-
-    const packageLocations = Array.isArray(payload.locations) ? payload.locations : [];
-    if (packageLocations.length > 0) {
-      for (const location of packageLocations) {
-        const packageDir = resolve(location);
-        const stats = await stat(packageDir);
-        if (!stats.isDirectory()) {
-          throw new Error(
-            `Module "${moduleName}" resolved to "${packageDir}", but it is not a package directory`
-          );
-        }
-        watchTargets.push({ moduleName, path: packageDir, kind: 'directory' });
-      }
-      continue;
-    }
-
-    if (typeof payload.origin !== 'string' || !payload.origin.endsWith('.py')) {
-      throw new Error(
-        `Module "${moduleName}" is not backed by a local Python source file or package directory and cannot be watched`
-      );
-    }
-
-    const modulePath = resolve(payload.origin);
-    const stats = await stat(modulePath);
-    if (!stats.isFile()) {
-      throw new Error(
-        `Module "${moduleName}" resolved to "${modulePath}", but it is not a Python source file`
-      );
-    }
-
-    watchTargets.push({ moduleName, path: modulePath, kind: 'file' });
+    watchTargets.push(...(await resolveModuleWatchTargets(moduleName, pythonEnv)));
   }
 
   return watchTargets;
@@ -786,6 +828,28 @@ export async function startNodeWatchSession<T extends RuntimeExecution & Disposa
     return watcherRefreshPromise;
   };
 
+  interface ReloadState {
+    stage: StageResult | null;
+    nextBridge: T | null;
+    preparedWatchers: PreparedWatchers | null;
+  }
+
+  interface PreparedReload {
+    stage: StageResult;
+    preparedWatchers: PreparedWatchers;
+    nextIgnoredPaths: string[];
+    watchPaths: string[];
+  }
+
+  const disposeReloadFailure = async (state: ReloadState): Promise<void> => {
+    if (state.preparedWatchers) {
+      closePreparedWatchers(state.preparedWatchers);
+    }
+    if (state.nextBridge) {
+      await state.nextBridge.dispose().catch(() => {});
+    }
+  };
+
   const runReload = async (trigger: { path?: string; manual: boolean }): Promise<boolean> => {
     if (closed) {
       return false;
@@ -793,20 +857,18 @@ export async function startNodeWatchSession<T extends RuntimeExecution & Disposa
 
     emit({ type: 'reload-start', path: trigger.path, manual: trigger.manual });
 
-    let stage: StageResult | null = null;
-    let nextBridge: T | null = null;
-    let preparedWatchers: PreparedWatchers | null = null;
+    const state: ReloadState = { stage: null, nextBridge: null, preparedWatchers: null };
 
     const abortReload = async (
       managerToDispose: ManagedBridgeReloader<T> | null = null
     ): Promise<boolean> => {
-      if (preparedWatchers) {
-        closePreparedWatchers(preparedWatchers);
-        preparedWatchers = null;
+      if (state.preparedWatchers) {
+        closePreparedWatchers(state.preparedWatchers);
+        state.preparedWatchers = null;
       }
-      if (nextBridge) {
-        await nextBridge.dispose().catch(() => {});
-        nextBridge = null;
+      if (state.nextBridge) {
+        await state.nextBridge.dispose().catch(() => {});
+        state.nextBridge = null;
       }
       if (managerToDispose) {
         await managerToDispose.dispose().catch(() => {});
@@ -814,10 +876,13 @@ export async function startNodeWatchSession<T extends RuntimeExecution & Disposa
       return false;
     };
 
-    try {
-      stage = await generateToStage(configFile);
+    // Generate the next stage, prepare watchers, and warm the next bridge.
+    // Returns null when the session closed mid-flight (caller aborts).
+    const prepareReload = async (): Promise<PreparedReload | null> => {
+      const stage = await generateToStage(configFile);
+      state.stage = stage;
       if (closed) {
-        return abortReload();
+        return null;
       }
       currentBridgeConfig = stage.config;
       const nextIgnoredPaths = buildIgnoredPaths(stage.outputDir);
@@ -828,17 +893,50 @@ export async function startNodeWatchSession<T extends RuntimeExecution & Disposa
         ...extraWatchSources,
       ]);
       const watchPaths = normalizePaths(watchSources.map(source => source.path));
-      preparedWatchers = await prepareWatchers(watchSources, nextIgnoredPaths);
+      const preparedWatchers = await prepareWatchers(watchSources, nextIgnoredPaths);
+      state.preparedWatchers = preparedWatchers;
       if (closed) {
-        return abortReload();
+        return null;
       }
 
       if (bridgeManager) {
-        nextBridge = await bridgeManager.prepareNextBridge();
+        state.nextBridge = await bridgeManager.prepareNextBridge();
         if (closed) {
-          return abortReload();
+          return null;
         }
       }
+
+      return { stage, preparedWatchers, nextIgnoredPaths, watchPaths };
+    };
+
+    // Activate (or create) the bridge for the freshly prepared stage.
+    // Returns the manager to dispose (or null) when the session closed
+    // mid-flight, otherwise null; sets `closedDuringActivation` accordingly.
+    let closedDuringActivation = false;
+    const activateReloadBridge = async (): Promise<ManagedBridgeReloader<T> | null> => {
+      if (bridgeManager && state.nextBridge) {
+        await bridgeManager.activatePreparedBridge(state.nextBridge);
+        state.nextBridge = null;
+        closedDuringActivation = closed;
+        return null;
+      }
+      if (!bridgeManager) {
+        const createdBridgeManager = await ManagedBridgeReloader.create(createBridgeForSession);
+        if (closed) {
+          closedDuringActivation = true;
+          return createdBridgeManager;
+        }
+        bridgeManager = createdBridgeManager;
+      }
+      return null;
+    };
+
+    try {
+      const prepared = await prepareReload();
+      if (!prepared) {
+        return abortReload();
+      }
+      const { stage } = prepared;
 
       const previousManagedFiles =
         activeOutputDir === stage.outputDir
@@ -853,29 +951,20 @@ export async function startNodeWatchSession<T extends RuntimeExecution & Disposa
         return abortReload();
       }
 
-      if (bridgeManager && nextBridge) {
-        await bridgeManager.activatePreparedBridge(nextBridge);
-        nextBridge = null;
-        if (closed) {
-          return abortReload();
-        }
-      } else if (!bridgeManager) {
-        const createdBridgeManager = await ManagedBridgeReloader.create(createBridgeForSession);
-        if (closed) {
-          return abortReload(createdBridgeManager);
-        }
-        bridgeManager = createdBridgeManager;
+      const managerToDispose = await activateReloadBridge();
+      if (closedDuringActivation) {
+        return abortReload(managerToDispose);
       }
 
       managedFiles = promotedManagedFiles;
       activeOutputDir = stage.outputDir;
-      ignoredPaths = nextIgnoredPaths;
-      commitWatchers(preparedWatchers);
+      ignoredPaths = prepared.nextIgnoredPaths;
+      commitWatchers(prepared.preparedWatchers);
       emit({
         type: 'reload-success',
         path: trigger.path,
         manual: trigger.manual,
-        paths: watchPaths,
+        paths: prepared.watchPaths,
         written: [...stage.files.keys()].sort(),
         warnings: stage.warnings,
       });
@@ -883,12 +972,7 @@ export async function startNodeWatchSession<T extends RuntimeExecution & Disposa
       return true;
     } catch (error) {
       lastReloadError = error instanceof Error ? error : new Error(String(error));
-      if (preparedWatchers) {
-        closePreparedWatchers(preparedWatchers);
-      }
-      if (nextBridge) {
-        await nextBridge.dispose().catch(() => {});
-      }
+      await disposeReloadFailure(state);
       emit({
         type: 'reload-error',
         path: trigger.path,
@@ -897,8 +981,8 @@ export async function startNodeWatchSession<T extends RuntimeExecution & Disposa
       });
       return false;
     } finally {
-      if (stage) {
-        await rm(stage.tempDir, { recursive: true, force: true });
+      if (state.stage) {
+        await rm(state.stage.tempDir, { recursive: true, force: true });
       }
     }
   };

--- a/src/runtime/bridge-codec.ts
+++ b/src/runtime/bridge-codec.ts
@@ -410,6 +410,60 @@ export class BridgeCodec {
     return bridgeError;
   }
 
+  /**
+   * Shared prelude for both decode paths: size guard, JSON parse (with bytes
+   * revival), protocol-version validation, and RPC-envelope unwrapping.
+   *
+   * Behavior-preserving extraction of the common head of decodeResponse and
+   * decodeResponseAsync; the only divergence between the two is what they do
+   * with the returned result (sync returns it as-is, async applies Arrow
+   * decoding) and so that divergence stays in the callers.
+   */
+  private parseResponseResult(payload: string): unknown {
+    // Check payload size first
+    const payloadBytes = new TextEncoder().encode(payload).length;
+    if (payloadBytes > this.maxPayloadBytes) {
+      throw new BridgeCodecError(
+        `Response payload size ${payloadBytes} bytes exceeds maximum ${this.maxPayloadBytes} bytes`,
+        { codecPhase: 'decode', valueType: 'payload' }
+      );
+    }
+
+    // Parse JSON
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(payload, this.reviveValueBound);
+    } catch (err) {
+      if (err instanceof BridgeCodecError || err instanceof BridgeProtocolError) {
+        throw err;
+      }
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      throw new BridgeCodecError(
+        `JSON parse failed: ${errorMessage}. Payload snippet: ${summarizePayloadForError(payload)}`,
+        { codecPhase: 'decode', valueType: 'json' }
+      );
+    }
+
+    // Validate protocol version (if present)
+    validateProtocolVersion(parsed);
+
+    return this.extractResultFromRpcResponse(parsed);
+  }
+
+  /**
+   * Post-decode guard: reject non-finite numbers (NaN/Infinity) when enabled.
+   * Shared by both decode paths.
+   */
+  private assertNoSpecialFloats(value: unknown): void {
+    if (this.rejectSpecialFloats && containsSpecialFloat(value)) {
+      const floatPath = findSpecialFloatPath(value);
+      throw new BridgeCodecError(
+        `Response contains non-finite number (NaN or Infinity) at ${floatPath}`,
+        { codecPhase: 'decode', valueType: 'number' }
+      );
+    }
+  }
+
   private extractResultFromRpcResponse(parsed: unknown): unknown {
     if (isRpcResponse(parsed)) {
       const response = parsed;
@@ -526,43 +580,10 @@ export class BridgeCodec {
    * @throws BridgeExecutionError if response contains a Python error
    */
   decodeResponse<T>(payload: string): T {
-    // Check payload size first
-    const payloadBytes = new TextEncoder().encode(payload).length;
-    if (payloadBytes > this.maxPayloadBytes) {
-      throw new BridgeCodecError(
-        `Response payload size ${payloadBytes} bytes exceeds maximum ${this.maxPayloadBytes} bytes`,
-        { codecPhase: 'decode', valueType: 'payload' }
-      );
-    }
-
-    // Parse JSON
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(payload, this.reviveValueBound);
-    } catch (err) {
-      if (err instanceof BridgeCodecError || err instanceof BridgeProtocolError) {
-        throw err;
-      }
-      const errorMessage = err instanceof Error ? err.message : String(err);
-      throw new BridgeCodecError(
-        `JSON parse failed: ${errorMessage}. Payload snippet: ${summarizePayloadForError(payload)}`,
-        { codecPhase: 'decode', valueType: 'json' }
-      );
-    }
-
-    // Validate protocol version (if present)
-    validateProtocolVersion(parsed);
-
-    const result = this.extractResultFromRpcResponse(parsed);
+    const result = this.parseResponseResult(payload);
 
     // Post-decode validation for special floats if enabled
-    if (this.rejectSpecialFloats && containsSpecialFloat(result)) {
-      const floatPath = findSpecialFloatPath(result);
-      throw new BridgeCodecError(
-        `Response contains non-finite number (NaN or Infinity) at ${floatPath}`,
-        { codecPhase: 'decode', valueType: 'number' }
-      );
-    }
+    this.assertNoSpecialFloats(result);
 
     return result as T;
   }
@@ -578,34 +599,7 @@ export class BridgeCodec {
    * @throws BridgeExecutionError if response contains a Python error
    */
   async decodeResponseAsync<T>(payload: string): Promise<T> {
-    // Check payload size first
-    const payloadBytes = new TextEncoder().encode(payload).length;
-    if (payloadBytes > this.maxPayloadBytes) {
-      throw new BridgeCodecError(
-        `Response payload size ${payloadBytes} bytes exceeds maximum ${this.maxPayloadBytes} bytes`,
-        { codecPhase: 'decode', valueType: 'payload' }
-      );
-    }
-
-    // Parse JSON
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(payload, this.reviveValueBound);
-    } catch (err) {
-      if (err instanceof BridgeCodecError || err instanceof BridgeProtocolError) {
-        throw err;
-      }
-      const errorMessage = err instanceof Error ? err.message : String(err);
-      throw new BridgeCodecError(
-        `JSON parse failed: ${errorMessage}. Payload snippet: ${summarizePayloadForError(payload)}`,
-        { codecPhase: 'decode', valueType: 'json' }
-      );
-    }
-
-    // Validate protocol version (if present)
-    validateProtocolVersion(parsed);
-
-    const result = this.extractResultFromRpcResponse(parsed);
+    const result = this.parseResponseResult(payload);
 
     // Apply Arrow decoding to the result
     let decoded: unknown;
@@ -621,13 +615,7 @@ export class BridgeCodec {
 
     // Post-decode validation for special floats if enabled
     // Note: Arrow decoders can introduce NaN/Infinity from binary representations.
-    if (this.rejectSpecialFloats && containsSpecialFloat(decoded)) {
-      const floatPath = findSpecialFloatPath(decoded);
-      throw new BridgeCodecError(
-        `Response contains non-finite number (NaN or Infinity) at ${floatPath}`,
-        { codecPhase: 'decode', valueType: 'number' }
-      );
-    }
+    this.assertNoSpecialFloats(decoded);
 
     return decoded as T;
   }

--- a/src/runtime/rpc-client.ts
+++ b/src/runtime/rpc-client.ts
@@ -281,26 +281,7 @@ export class RpcClient extends DisposableBase {
     message: Omit<ProtocolMessage, 'id' | 'protocol'>,
     options?: ExecuteOptions<T>
   ): Promise<T> {
-    const fullMessage: ProtocolMessage = {
-      ...message,
-      id: this.generateId(),
-      protocol: PROTOCOL_ID,
-    };
-
-    return this.execute(async () => {
-      // 1. Encode request (validates args)
-      const encoded = this.codec.encodeRequest(fullMessage);
-
-      // 2. Send via transport
-      const responseStr = await this.transport.send(
-        encoded,
-        options?.timeoutMs ?? this.defaultTimeoutMs,
-        options?.signal
-      );
-
-      // 3. Decode response (validates result)
-      return this.codec.decodeResponse<T>(responseStr);
-    }, options);
+    return this.sendVia(message, options, responseStr => this.codec.decodeResponse<T>(responseStr));
   }
 
   /**
@@ -321,11 +302,27 @@ export class RpcClient extends DisposableBase {
     message: Omit<ProtocolMessage, 'id' | 'protocol'>,
     options?: ExecuteOptions<T>
   ): Promise<T> {
-    const fullMessage: ProtocolMessage = {
-      ...message,
-      id: this.generateId(),
-      protocol: PROTOCOL_ID,
-    };
+    return this.sendVia(message, options, responseStr =>
+      this.codec.decodeResponseAsync<T>(responseStr)
+    );
+  }
+
+  /**
+   * Shared body for sendMessage/sendMessageAsync: stamp the frame, run the
+   * encode -> transport.send -> decode pipeline inside this.execute() (which
+   * supplies auto-init, timeout/retry/abort), where the only difference between
+   * the sync and Arrow-aware paths is the supplied `decode` step.
+   *
+   * Behavior-preserving extraction of the two twins; ordering, the
+   * `options?.timeoutMs ?? this.defaultTimeoutMs` fallback, and the
+   * `this.execute(..., options)` wrapping are unchanged.
+   */
+  private async sendVia<T>(
+    message: Omit<ProtocolMessage, 'id' | 'protocol'>,
+    options: ExecuteOptions<T> | undefined,
+    decode: (responseStr: string) => T | Promise<T>
+  ): Promise<T> {
+    const fullMessage = this.stampMessage(message);
 
     return this.execute(async () => {
       // 1. Encode request (validates args)
@@ -338,8 +335,8 @@ export class RpcClient extends DisposableBase {
         options?.signal
       );
 
-      // 3. Decode response with Arrow support
-      return this.codec.decodeResponseAsync<T>(responseStr);
+      // 3. Decode response (sync or Arrow-aware, per caller)
+      return decode(responseStr);
     }, options);
   }
 
@@ -364,11 +361,7 @@ export class RpcClient extends DisposableBase {
     message: Omit<ProtocolMessage, 'id' | 'protocol'>,
     opts?: { timeoutMs?: number; signal?: AbortSignal }
   ): Promise<T> {
-    const fullMessage: ProtocolMessage = {
-      ...message,
-      id: this.generateId(),
-      protocol: PROTOCOL_ID,
-    };
+    const fullMessage = this.stampMessage(message);
     const encoded = this.codec.encodeRequest(fullMessage);
     const responseStr = await transport.send(
       encoded,
@@ -376,6 +369,20 @@ export class RpcClient extends DisposableBase {
       opts?.signal
     );
     return this.codec.decodeResponseAsync<T>(responseStr);
+  }
+
+  /**
+   * Stamp a partial message into a full wire frame: assign the next request id
+   * and the protocol marker. The single id counter + protocol stamping live
+   * here so every send path (sendMessage/sendMessageAsync/sendOn) is correlated
+   * identically.
+   */
+  private stampMessage(message: Omit<ProtocolMessage, 'id' | 'protocol'>): ProtocolMessage {
+    return {
+      ...message,
+      id: this.generateId(),
+      protocol: PROTOCOL_ID,
+    };
   }
 
   /**

--- a/src/runtime/subprocess-transport.ts
+++ b/src/runtime/subprocess-transport.ts
@@ -14,6 +14,7 @@
  */
 
 import { spawn, type ChildProcess } from 'child_process';
+import type { Writable } from 'stream';
 import { DisposableBase } from './bounded-context.js';
 import { BridgeDisposedError, BridgeProtocolError, BridgeTimeoutError } from './errors.js';
 import { TimedOutRequestTracker } from './timed-out-request-tracker.js';
@@ -765,19 +766,79 @@ export class SubprocessTransport extends DisposableBase implements Transport {
   }
 
   /**
+   * Reject and clear every entry currently in the write queue.
+   * Clears each entry's timeout before rejecting so no late timer fires.
+   */
+  private rejectAllQueuedWrites(error: Error): void {
+    for (const q of this.writeQueue) {
+      this.clearQueuedWriteTimeout(q);
+      q.reject(error);
+    }
+    this.writeQueue.length = 0;
+  }
+
+  /**
+   * Process a single dequeued write entry: enforce the fallback queue timeout,
+   * then attempt the stdin write. The returned status tells {@link flushWriteQueue}
+   * how to proceed:
+   * - `'continue'`: entry settled (written or timed out); process the next entry.
+   * - `'backpressure'`: write accepted but stream is full; pause until the next drain.
+   * - `'error'`: synchronous write failure; the caller must reject the remaining queue.
+   *
+   * The entry's own timeout must already be cleared by the caller before this runs.
+   */
+  private processQueuedWrite(
+    queued: QueuedWrite,
+    stdin: Writable,
+    now: number
+  ): 'continue' | 'backpressure' | 'error' {
+    // Check for write queue timeout (fallback check, timer should have handled this)
+    if (now - queued.queuedAt > this.writeQueueTimeoutMs) {
+      queued.reject(
+        new BridgeTimeoutError(
+          `Write queue timeout: entry waited ${now - queued.queuedAt}ms (limit: ${this.writeQueueTimeoutMs}ms)`
+        )
+      );
+      return 'continue';
+    }
+
+    try {
+      const canWrite = stdin.write(queued.data);
+
+      if (canWrite) {
+        queued.resolve();
+        return 'continue';
+      }
+
+      // Backpressure - this write has been accepted by stream buffer.
+      // Pause further queued writes until the next "drain" event.
+      queued.resolve();
+      this.draining = true;
+      return 'backpressure';
+    } catch (err) {
+      // Synchronous write error (e.g., EPIPE) - reject this entry; caller rejects the rest.
+      const errorMessage = err instanceof Error ? err.message : 'unknown';
+      const error = new BridgeProtocolError(this.withStderrTail(`Write error: ${errorMessage}`));
+      queued.reject(error);
+      this.rejectAllQueuedWrites(error);
+      this.markForRestart();
+      return 'error';
+    }
+  }
+
+  /**
    * Flush queued writes when backpressure clears.
    */
   private flushWriteQueue(): void {
     const now = Date.now();
 
     while (this.writeQueue.length > 0 && !this.draining) {
-      if (!this.process?.stdin || this.processExited) {
+      const stdin = this.process?.stdin;
+      if (!stdin || this.processExited) {
         // Process died - reject all queued writes
-        for (const q of this.writeQueue) {
-          this.clearQueuedWriteTimeout(q);
-          q.reject(new BridgeProtocolError(this.withStderrTail('Process stdin not available')));
-        }
-        this.writeQueue.length = 0;
+        this.rejectAllQueuedWrites(
+          new BridgeProtocolError(this.withStderrTail('Process stdin not available'))
+        );
         this.markForRestart();
         return;
       }
@@ -790,39 +851,8 @@ export class SubprocessTransport extends DisposableBase implements Transport {
       // Clear the timeout since we're processing this entry now
       this.clearQueuedWriteTimeout(queued);
 
-      // Check for write queue timeout (fallback check, timer should have handled this)
-      if (now - queued.queuedAt > this.writeQueueTimeoutMs) {
-        queued.reject(
-          new BridgeTimeoutError(
-            `Write queue timeout: entry waited ${now - queued.queuedAt}ms (limit: ${this.writeQueueTimeoutMs}ms)`
-          )
-        );
-        continue; // Process next entry
-      }
-
-      try {
-        const canWrite = this.process.stdin.write(queued.data);
-
-        if (canWrite) {
-          queued.resolve();
-        } else {
-          // Backpressure - this write has been accepted by stream buffer.
-          // Pause further queued writes until the next "drain" event.
-          queued.resolve();
-          this.draining = true;
-          return;
-        }
-      } catch (err) {
-        // Synchronous write error (e.g., EPIPE) - reject this and all remaining writes
-        const errorMessage = err instanceof Error ? err.message : 'unknown';
-        const error = new BridgeProtocolError(this.withStderrTail(`Write error: ${errorMessage}`));
-        queued.reject(error);
-        for (const q of this.writeQueue) {
-          this.clearQueuedWriteTimeout(q);
-          q.reject(error);
-        }
-        this.writeQueue.length = 0;
-        this.markForRestart();
+      const status = this.processQueuedWrite(queued, stdin, now);
+      if (status === 'backpressure' || status === 'error') {
         return;
       }
     }

--- a/src/tywrap.ts
+++ b/src/tywrap.ts
@@ -52,30 +52,6 @@ export async function tywrap(options: Partial<TywrapOptions> = {}): Promise<Tywr
   };
 }
 
-export default tywrap;
-
-/**
- * Append minimal tsd tests for a generated module (optional dev aid)
- */
-export async function emitTypeTestsForModule(
-  moduleName: string,
-  outDir = 'test-d/generated'
-): Promise<void> {
-  const { writeFile, mkdir } = await import('fs/promises');
-  const { join } = await import('path');
-  try {
-    await mkdir(outDir, { recursive: true });
-  } catch {}
-  const filePath = join(outDir, `${moduleName}.test-d.ts`);
-  const content = `import { expectType } from 'tsd';
-import * as mod from '../../generated/${moduleName}.generated.ts';
-
-// Opportunistic: ensure module namespace is an object
-expectType<Record<string, unknown>>(mod);
-`;
-  await writeFile(filePath, content, 'utf-8');
-}
-
 export interface GenerateRunOptions {
   /**
    * If true, do not write files; instead compare generated output to what's on disk.

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -149,73 +149,71 @@ export class ArtifactCache {
     hash.update(prefix);
     hash.update('\0');
 
-    // Add inputs
+    // Add inputs. Each input contributes a type tag, an optional payload, and a
+    // boundary separator so that "1" vs 1 and ["a","bc"] vs ["ab","c"] never collide.
     for (const input of inputs) {
-      // Why: disambiguate types so "1" and 1 don't collide, and keep input boundaries so
-      // ["a", "bc"] doesn't collide with ["ab", "c"].
-      if (input === undefined) {
-        hash.update('undef:');
-        hash.update('\0');
-        continue;
+      const { tag, payload } = ArtifactCache.encodeKeyInput(input);
+      hash.update(tag);
+      if (payload !== undefined) {
+        hash.update(payload);
       }
-      if (input === null) {
-        hash.update('null:');
-        hash.update('\0');
-        continue;
-      }
-      if (typeof input === 'string') {
-        hash.update('str:');
-        hash.update(input);
-        hash.update('\0');
-        continue;
-      }
-      if (typeof input === 'number') {
-        hash.update('num:');
-        hash.update(String(input));
-        hash.update('\0');
-        continue;
-      }
-      if (typeof input === 'boolean') {
-        hash.update('bool:');
-        hash.update(input ? '1' : '0');
-        hash.update('\0');
-        continue;
-      }
-      if (typeof input === 'bigint') {
-        hash.update('bigint:');
-        hash.update(input.toString());
-        hash.update('\0');
-        continue;
-      }
-      if (Buffer.isBuffer(input)) {
-        hash.update('buf:');
-        hash.update(input);
-        hash.update('\0');
-        continue;
-      }
-
-      if (typeof input === 'symbol') {
-        hash.update('sym:');
-        hash.update(input.toString());
-        hash.update('\0');
-        continue;
-      }
-
-      hash.update('json:');
-      let json: string;
-      try {
-        json =
-          JSON.stringify(input, (_key, value) =>
-            typeof value === 'symbol' ? value.toString() : value
-          ) ?? 'undefined';
-      } catch {
-        json = String(input);
-      }
-      hash.update(json);
       hash.update('\0');
     }
 
     return hash.digest('hex').substring(0, 16); // Use first 16 chars for readability
+  }
+
+  /**
+   * Encode a single key input as a type tag plus optional payload.
+   * Why: disambiguate types so "1" and 1 don't collide, and keep input boundaries so
+   * ["a", "bc"] doesn't collide with ["ab", "c"].
+   */
+  private static encodeKeyInput(input: unknown): {
+    tag: string;
+    payload?: string | Buffer;
+  } {
+    if (input === undefined) {
+      return { tag: 'undef:' };
+    }
+    if (input === null) {
+      return { tag: 'null:' };
+    }
+    if (typeof input === 'string') {
+      return { tag: 'str:', payload: input };
+    }
+    if (typeof input === 'number') {
+      return { tag: 'num:', payload: String(input) };
+    }
+    if (typeof input === 'boolean') {
+      return { tag: 'bool:', payload: input ? '1' : '0' };
+    }
+    if (typeof input === 'bigint') {
+      return { tag: 'bigint:', payload: input.toString() };
+    }
+    if (Buffer.isBuffer(input)) {
+      return { tag: 'buf:', payload: input };
+    }
+    if (typeof input === 'symbol') {
+      return { tag: 'sym:', payload: input.toString() };
+    }
+
+    return { tag: 'json:', payload: ArtifactCache.stringifyKeyInput(input) };
+  }
+
+  /**
+   * Stringify an arbitrary key input for hashing, normalizing symbols and
+   * falling back to String() when JSON serialization fails.
+   */
+  private static stringifyKeyInput(input: unknown): string {
+    try {
+      return (
+        JSON.stringify(input, (_key, value) =>
+          typeof value === 'symbol' ? value.toString() : value
+        ) ?? 'undefined'
+      );
+    } catch {
+      return String(input);
+    }
   }
 
   /**

--- a/src/utils/python.ts
+++ b/src/utils/python.ts
@@ -44,30 +44,43 @@ export function getDefaultPythonPath(): string {
   return getPythonExecutableName();
 }
 
+/**
+ * Whether the configured pythonPath is the default interpreter (or unset),
+ * meaning a virtual environment lookup should take precedence.
+ */
+function usesDefaultPython(pythonPath: string | undefined): boolean {
+  return !pythonPath || pythonPath === 'python3' || pythonPath === 'python';
+}
+
+/**
+ * Resolve the Python executable inside a virtual environment, preferring the
+ * Node path module when available and falling back to cross-runtime pathUtils.
+ */
+async function resolveVenvPython(virtualEnv: string, cwd: string): Promise<string> {
+  const binDir = getVenvBinDir();
+  const exe = getVenvPythonExe();
+  const pathMod = await loadNodePathModule();
+
+  if (pathMod) {
+    const venvRoot = pathMod.resolve(cwd, virtualEnv);
+    return pathMod.join(venvRoot, binDir, exe);
+  }
+
+  const venvRoot = isAbsolutePath(virtualEnv)
+    ? pathUtils.join(virtualEnv)
+    : pathUtils.join(cwd, virtualEnv);
+  return pathUtils.join(venvRoot, binDir, exe);
+}
+
 export async function resolvePythonExecutable(options: PythonResolveOptions = {}): Promise<string> {
   const pythonPath = options.pythonPath?.trim();
   const virtualEnv = options.virtualEnv?.trim();
 
-  if (virtualEnv) {
-    const usesDefaultPython = !pythonPath || pythonPath === 'python3' || pythonPath === 'python';
-    if (usesDefaultPython) {
-      const cwd =
-        options.cwd ??
-        (typeof process !== 'undefined' && typeof process.cwd === 'function' ? process.cwd() : '.');
-      const binDir = getVenvBinDir();
-      const exe = getVenvPythonExe();
-      const pathMod = await loadNodePathModule();
-
-      if (pathMod) {
-        const venvRoot = pathMod.resolve(cwd, virtualEnv);
-        return pathMod.join(venvRoot, binDir, exe);
-      }
-
-      const venvRoot = isAbsolutePath(virtualEnv)
-        ? pathUtils.join(virtualEnv)
-        : pathUtils.join(cwd, virtualEnv);
-      return pathUtils.join(venvRoot, binDir, exe);
-    }
+  if (virtualEnv && usesDefaultPython(pythonPath)) {
+    const cwd =
+      options.cwd ??
+      (typeof process !== 'undefined' && typeof process.cwd === 'function' ? process.cwd() : '.');
+    return resolveVenvPython(virtualEnv, cwd);
   }
 
   if (pythonPath) {

--- a/src/utils/runtime.ts
+++ b/src/utils/runtime.ts
@@ -230,25 +230,36 @@ async function loadPathModule(): Promise<PathModule | null> {
 }
 
 /**
+ * Apply a single path segment to the accumulated normalized segments,
+ * resolving '..' and dropping '.'/empty segments in place.
+ */
+function applyPathSegment(normalized: string[], segment: string, isAbsolute: boolean): void {
+  if (segment === '.' || segment === '') {
+    return; // Skip current directory and empty segments
+  }
+
+  if (segment !== '..') {
+    normalized.push(segment);
+    return;
+  }
+
+  // '..' segment: go up one directory when possible.
+  if (normalized.length > 0 && normalized[normalized.length - 1] !== '..') {
+    normalized.pop();
+  } else if (!isAbsolute) {
+    normalized.push(segment); // Keep '..' if not absolute and at root
+  }
+}
+
+/**
  * Normalize path by stripping '.' and resolving '..' components
  */
 function normalizePath(path: string): string {
   const isAbsolute = path.startsWith('/');
-  const segments = path.split('/');
   const normalized: string[] = [];
 
-  for (const segment of segments) {
-    if (segment === '.' || segment === '') {
-      continue; // Skip current directory and empty segments
-    } else if (segment === '..') {
-      if (normalized.length > 0 && normalized[normalized.length - 1] !== '..') {
-        normalized.pop(); // Go up one directory
-      } else if (!isAbsolute) {
-        normalized.push(segment); // Keep '..' if not absolute and at root
-      }
-    } else {
-      normalized.push(segment);
-    }
+  for (const segment of path.split('/')) {
+    applyPathSegment(normalized, segment, isAbsolute);
   }
 
   const result = normalized.join('/');

--- a/src/version.ts
+++ b/src/version.ts
@@ -9,4 +9,4 @@
  * Regenerate with: node scripts/generate-version.mjs
  */
 
-export const VERSION: string = "0.6.0";
+export const VERSION: string = "0.6.1";


### PR DESCRIPTION
## 0.6.1 — maintenance patch (invisible)

The 0.6.1 cleanup slice from the ts-fx review. **No API, behavior, or wire-protocol changes** — purely internal. Built as a stacked agent workflow (9 scopes), each characterization-gated (snapshot before/after, assert identical) and verified.

### What changed
- Removed 2 dead exports (`emitTypeTestsForModule`, redundant `export default tywrap`) — neither on the public surface.
- Decomposed the 11 worst remaining complexity hotspots, output-preserved: `generateKey` (cache), `validateTypeHints` (validation), the `dev.ts` watch/reload trio, `flushWriteQueue` (subprocess transport), discovery dependency/path helpers, `normalizePath`/`resolvePythonExecutable` (utils), `parseTypingFactoryName` (annotation parser).
- Factored the duplicated request/response dispatch in `bridge-codec` and `rpc-client` into one path (the cross-bridge `call`/`instantiate` merge was deliberately left alone as too risky for a patch).

### Result
- fx **actionable complexity: 14 → 3** — the remaining three (`generate` cog 91, `fetchPythonIr` cog 27 → 0.7.0; `splitTopLevel` → intentionally irreducible) are deferred.
- typecheck ✓ · build ✓ · lint 0 errors ✓ · tsd ✓ · **full suite 1232 passed / 0 failed / 130 skipped** (identical to 0.6.0 — behavior preserved).

Carries the version bump + human CHANGELOG so the merge cuts 0.6.1 via `publish_from_main`.
