### PR TITLE
ci: remove vestigial release-please job from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release Please
+name: Release
 
 on:
   push:
@@ -12,7 +12,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   detect_release_state:
@@ -73,20 +72,6 @@ jobs:
           echo "publish_from_main=${PUBLISH_FROM_MAIN}" >> "$GITHUB_OUTPUT"
           echo "publish_existing_tag=${PUBLISH_EXISTING_TAG}" >> "$GITHUB_OUTPUT"
 
-  release_please:
-    needs: detect_release_state
-    if: ${{ needs.detect_release_state.outputs.publish_from_main != 'true' && needs.detect_release_state.outputs.publish_existing_tag != 'true' }}
-    runs-on: ubuntu-latest
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created || 'false' }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
-    steps:
-      - uses: googleapis/release-please-action@v5
-        id: release
-        with:
-          release-type: node
-          token: ${{ secrets.GITHUB_TOKEN }}
-
   publish_existing_main_release:
     needs: detect_release_state
     if: ${{ needs.detect_release_state.outputs.publish_from_main == 'true' }}
@@ -143,12 +128,11 @@ jobs:
           echo "tag_name=${TAG_NAME}" >> "$GITHUB_OUTPUT"
 
   publish_npm:
-    needs: [detect_release_state, release_please, publish_existing_main_release]
+    needs: [detect_release_state, publish_existing_main_release]
     if: >-
       ${{
         always() &&
         (
-          needs.release_please.outputs.release_created == 'true' ||
           needs.publish_existing_main_release.outputs.release_ready == 'true' ||
           needs.detect_release_state.outputs.publish_existing_tag == 'true'
         )
@@ -163,8 +147,6 @@ jobs:
         with:
           ref: >-
             ${{
-              needs.release_please.outputs.release_created == 'true' &&
-              needs.release_please.outputs.tag_name ||
               needs.publish_existing_main_release.outputs.release_ready == 'true' &&
               needs.publish_existing_main_release.outputs.tag_name ||
               needs.detect_release_state.outputs.tag_name

--- a/docs/release.md
+++ b/docs/release.md
@@ -2,37 +2,38 @@
 
 ## tywrap (npm)
 
-1. Ensure the working tree is clean and `main` is up to date.
+Releases publish from `main` via the [`release.yml`](../.github/workflows/release.yml)
+workflow. There is one path: bump the version on a branch, merge to `main`, and the
+workflow tags, releases, and publishes.
 
-2. Check the release-please branch or PR for the next npm release. Verify:
-   - `package.json`
-   - `package-lock.json`
-   - `src/index.ts`
-   - `CHANGELOG.md`
+1. On a release branch, bump the version and update the changelog:
+   - `package.json` — the new `version`
+   - `CHANGELOG.md` — add a `## [X.Y.Z](…compare/vPREV...vX.Y.Z) (DATE)` section
+     (the workflow extracts the GitHub release notes from this exact header)
+   - `src/version.ts` — regenerate with `npm run build:version` (single-sourced
+     from `package.json`)
+   - `package-lock.json` — refresh if dependencies changed
 
-3. Run the release gate in CI-style mode:
+2. Run the release gate:
    ```sh
    CI=1 npm run check:all
    ```
 
-4. Merge the reviewed release branch or PR to `main`. The [`release.yml`](../.github/workflows/release.yml)
-   workflow has two paths:
-   - normal path: `release-please` opens or updates the release PR, then creates the npm tag and release after that PR is merged
-   - fallback path: if `main` already contains an unreleased `package.json` version with a matching `CHANGELOG.md` section, the workflow tags and publishes that version directly from `main`
+3. Open a PR, get CI green, and merge to `main`. On that push `release.yml`
+   detects that `main` carries an unreleased `package.json` version with a
+   matching `CHANGELOG.md` section and no existing tag, then tags `vX.Y.Z`,
+   creates the GitHub release from that changelog section, and publishes to npm.
 
-5. npm publishing uses npm trusted publishing from GitHub Actions. Keep the npm
-   package connected to this repository as a trusted publisher, and do not add a
-   publish token to the workflow for the normal release path. The release job
-   validates the tagged package on Node 22, then switches to Node 24 for the
-   final `npm publish --provenance` step so npm uses an OIDC-capable CLI.
+4. npm publishing uses npm trusted publishing (OIDC) from GitHub Actions — keep
+   the package connected to this repository as a trusted publisher, and do not
+   add a publish token to the workflow. The publish job validates on Node 22,
+   then switches to Node 24 for the final `npm publish --provenance` step so npm
+   uses an OIDC-capable CLI.
 
-6. For the normal `release-please` path, keep the repository Actions setting
-   `Allow GitHub Actions to create and approve pull requests` enabled.
+5. To (re)publish an already-tagged version without changing `main`, run the
+   `Release` workflow manually with `publish_tag=vX.Y.Z`.
 
-7. To publish an existing release tag without opening a new release PR, run the
-   `Release Please` workflow manually with `publish_tag=vX.Y.Z`.
-
-8. If GitHub Actions release automation is unavailable, use the manual fallback:
+6. If GitHub Actions release automation is unavailable, use the manual fallback:
    ```sh
    node scripts/release.mjs <version> --commit --tag
    git push && git push --tags


### PR DESCRIPTION
## Problem
The `release_please` job (googleapis/release-please-action) runs on every non-release push to `main` and **fails** with `Validation Failed … already_exists` — it keeps trying to create a release for the already-merged release-please PR #253 (`v0.5.1`). It surfaced on the 0.7.0 docs-fix commit.

## Why removing it is safe
Every release since 0.5.1 shipped via the custom **`publish_from_main`** path (humans bump `package.json` + `CHANGELOG.md`; the workflow tags + releases + publishes). `release_please` was *skipped* on the 0.6.1 and 0.7.0 release runs — the repo doesn't use its automated version-bump PRs.

## Changes
- Delete the `release_please` job and its three consumers in `publish_npm` (`needs`, the `release_created` `if`-clause, the checkout `ref` ternary).
- Drop the now-unused top-level `pull-requests: write`.
- Rename the workflow `Release Please` → `Release`.
- Update `docs/release.md` to document `publish_from_main` as the sole path.

## Verification
The `publish_from_main` and `workflow_dispatch publish_existing_tag` paths are unchanged. Confirmed by two independent agents + a codex audit: both release paths still trigger `publish_npm` and check out the correct ref (`always()` keeps `publish_npm` evaluating when `publish_existing_main_release` is skipped; the `&&`/`||` ref ternary falls through to `detect_release_state.tag_name`), and ordinary pushes to main now go green. YAML parses; no `release_please` references remain anywhere.