### PR TITLE
fix(runtime)!: remove heuristic call-result caching (enableCache)

### DIFF
--- a/docs/guide/runtimes/node.md
+++ b/docs/guide/runtimes/node.md
@@ -160,7 +160,6 @@ const bridge = new NodeBridge({
 | `maxProcesses`            | `number`                                 | `1`             | Maximum worker count                     |
 | `maxConcurrentPerProcess` | `number`                                 | `10`            | Concurrent requests per worker           |
 | `inheritProcessEnv`       | `boolean`                                | `false`         | Pass the full parent environment through |
-| `enableCache`             | `boolean`                                | `false`         | Cache pure function results              |
 | `env`                     | `Record<string, string \| undefined>`    | `{}`            | Extra subprocess env vars                |
 | `codec`                   | `CodecOptions`                           | —               | Codec validation and byte handling       |
 | `warmupCommands`          | `Array<{ module, functionName, args? }>` | `[]`            | Commands to run when each worker starts  |

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -1254,7 +1254,6 @@ const bridge = new NodeBridge({
 | `maxProcesses`            | `number`                                 | `1`             | Maximum worker count                     |
 | `maxConcurrentPerProcess` | `number`                                 | `10`            | Concurrent requests per worker           |
 | `inheritProcessEnv`       | `boolean`                                | `false`         | Pass the full parent environment through |
-| `enableCache`             | `boolean`                                | `false`         | Cache pure function results              |
 | `env`                     | `Record<string, string \| undefined>`    | `{}`            | Extra subprocess env vars                |
 | `codec`                   | `CodecOptions`                           | —               | Codec validation and byte handling       |
 | `warmupCommands`          | `Array<{ module, functionName, args? }>` | `[]`            | Commands to run when each worker starts  |
@@ -3219,7 +3218,6 @@ const info = await bridge.getBridgeInfo({ refresh: true });
 | `maxProcesses`            | `1`             | Maximum worker count                            |
 | `maxConcurrentPerProcess` | `10`            | Concurrent requests per worker                  |
 | `inheritProcessEnv`       | `false`         | Pass full parent env through                    |
-| `enableCache`             | `false`         | Cache pure function results                     |
 | `env`                     | `{}`            | Extra subprocess env vars                       |
 | `codec`                   | —               | `CodecOptions` for validation and byte handling |
 | `warmupCommands`          | `[]`            | Per-worker startup calls                        |

--- a/docs/reference/api/index.md
+++ b/docs/reference/api/index.md
@@ -142,7 +142,6 @@ const info = await bridge.getBridgeInfo({ refresh: true });
 | `maxProcesses`            | `1`             | Maximum worker count                            |
 | `maxConcurrentPerProcess` | `10`            | Concurrent requests per worker                  |
 | `inheritProcessEnv`       | `false`         | Pass full parent env through                    |
-| `enableCache`             | `false`         | Cache pure function results                     |
 | `env`                     | `{}`            | Extra subprocess env vars                       |
 | `codec`                   | —               | `CodecOptions` for validation and byte handling |
 | `warmupCommands`          | `[]`            | Per-worker startup calls                        |

--- a/src/runtime/base-bridge.ts
+++ b/src/runtime/base-bridge.ts
@@ -3,12 +3,11 @@
  *
  * The three bridge facades (NodeBridge/HttpBridge/PyodideBridge) all extend
  * DisposableBase (lifecycle/resources) and implement PythonRuntime by HOLDING
- * an RpcClient. The PythonRuntime delegation was byte-identical across all
+ * an RpcClient. The PythonRuntime delegation is byte-identical across all
  * three: each method does `await this.ensureReady()` then forwards to the held
  * RpcClient. This base collapses that duplication onto a single
  * `getRpcClient()` accessor while leaving each facade free to own its own
- * RpcClient field (for constructor wiring, resource tracking, and — in
- * NodeBridge's case — a caching override of call()).
+ * RpcClient field for constructor wiring and resource tracking.
  *
  * It carries no transport/codec/lifecycle specifics: doInit/doDispose remain
  * abstract on DisposableBase and stay per-facade.

--- a/src/runtime/node.ts
+++ b/src/runtime/node.ts
@@ -16,7 +16,6 @@ import { createRequire } from 'node:module';
 import { autoRegisterArrowDecoder } from '../utils/codec.js';
 import { getDefaultPythonPath } from '../utils/python.js';
 import { getVenvBinDir, getVenvPythonExe } from '../utils/runtime.js';
-import { globalCache } from '../utils/cache.js';
 
 import { BasePythonBridge } from './base-bridge.js';
 import { RpcClient } from './rpc-client.js';
@@ -63,9 +62,6 @@ export interface NodeBridgeOptions {
 
   /** Inherit all environment variables from parent process. Default: false */
   inheritProcessEnv?: boolean;
-
-  /** Enable result caching for pure functions. Default: false */
-  enableCache?: boolean;
 
   /** Optional extra environment variables to pass to the Python subprocess. */
   env?: Record<string, string | undefined>;
@@ -132,7 +128,6 @@ interface ResolvedOptions {
   timeoutMs: number;
   queueTimeoutMs: number;
   inheritProcessEnv: boolean;
-  enableCache: boolean;
   enableChunking: boolean;
   env: Record<string, string | undefined>;
   codec?: CodecOptions;
@@ -293,7 +288,6 @@ function normalizeWarmupCommands(commands: NodeBridgeOptions['warmupCommands']):
  * - Virtual environment support
  * - Full BridgeCodec validation (NaN/Infinity rejection, key validation)
  * - Automatic Arrow decoding for DataFrames/ndarrays
- * - Optional result caching for pure functions
  * - Process warmup commands
  *
  * @example
@@ -314,7 +308,6 @@ function normalizeWarmupCommands(commands: NodeBridgeOptions['warmupCommands']):
  * const pooledBridge = new NodeBridge({
  *   maxProcesses: 4,
  *   maxConcurrentPerProcess: 2,
- *   enableCache: true,
  * });
  * await pooledBridge.init();
  * ```
@@ -352,7 +345,6 @@ export class NodeBridge extends BasePythonBridge {
       timeoutMs: options.timeoutMs ?? 30000,
       queueTimeoutMs: options.queueTimeoutMs ?? 30000,
       inheritProcessEnv: options.inheritProcessEnv ?? false,
-      enableCache: options.enableCache ?? false,
       enableChunking: options.enableChunking ?? true,
       env: options.env ?? {},
       codec: options.codec,
@@ -457,55 +449,10 @@ export class NodeBridge extends BasePythonBridge {
 
   /**
    * Expose the held RpcClient to BasePythonBridge's shared delegating methods
-   * (instantiate/callMethod/disposeInstance/getBridgeInfo). call() is
-   * overridden below to layer caching on top.
+   * (call/instantiate/callMethod/disposeInstance/getBridgeInfo).
    */
   protected getRpcClient(): RpcClient {
     return this.rpc;
-  }
-
-  /**
-   * Call a Python function, with optional result caching.
-   *
-   * Overrides BasePythonBridge.call() to layer the cache lookup/writeback on
-   * top of the shared delegation. Cache lookup stays FIRST so cache hits return
-   * without forcing init, preserving the pre-composition behavior.
-   */
-  override async call<T = unknown>(
-    module: string,
-    functionName: string,
-    args: unknown[],
-    kwargs?: Record<string, unknown>
-  ): Promise<T> {
-    // Check cache if enabled
-    if (this.resolvedOptions.enableCache) {
-      const cacheKey = this.safeCacheKey('runtime_call', module, functionName, args, kwargs);
-      if (cacheKey) {
-        const cached = await globalCache.get<T>(cacheKey);
-        if (cached !== null) {
-          return cached;
-        }
-      }
-
-      // Execute and cache if pure function
-      const startTime = performance.now();
-      await this.ensureReady();
-      const result = await this.rpc.call<T>(module, functionName, args, kwargs);
-      const duration = performance.now() - startTime;
-
-      if (cacheKey && this.isPureFunctionCandidate(functionName, args)) {
-        await globalCache.set(cacheKey, result, {
-          computeTime: duration,
-          dependencies: [module],
-        });
-      }
-
-      return result;
-    }
-
-    // No caching - direct call
-    await this.ensureReady();
-    return this.rpc.call<T>(module, functionName, args, kwargs);
   }
 
   // ===========================================================================
@@ -560,52 +507,6 @@ export class NodeBridge extends BasePythonBridge {
       poolSize: poolStats.workerCount,
       busyWorkers: poolStats.totalInFlight,
     };
-  }
-
-  // ===========================================================================
-  // PRIVATE HELPERS
-  // ===========================================================================
-
-  /**
-   * Generate a cache key, returning null if generation fails.
-   */
-  private safeCacheKey(prefix: string, ...inputs: unknown[]): string | null {
-    try {
-      return globalCache.generateKey(prefix, ...inputs);
-    } catch {
-      return null;
-    }
-  }
-
-  /**
-   * Heuristic to determine if function result should be cached.
-   */
-  private isPureFunctionCandidate(functionName: string, args: unknown[]): boolean {
-    const pureFunctionPatterns = [
-      /^(get|fetch|read|load|find|search|query|select)_/i,
-      /^(compute|calculate|process|transform|convert)_/i,
-      /^(encode|decode|serialize|deserialize)_/i,
-    ];
-
-    const impureFunctionPatterns = [
-      /^(set|save|write|update|insert|delete|create|modify)_/i,
-      /^(send|post|put|patch)_/i,
-      /random|uuid|timestamp|now|current/i,
-    ];
-
-    if (impureFunctionPatterns.some(pattern => pattern.test(functionName))) {
-      return false;
-    }
-
-    if (pureFunctionPatterns.some(pattern => pattern.test(functionName))) {
-      return true;
-    }
-
-    const hasComplexArgs = args.some(
-      arg => arg !== null && typeof arg === 'object' && !(arg instanceof Date)
-    );
-
-    return !hasComplexArgs && args.length <= 3;
   }
 }
 

--- a/test/runtime_config.test.ts
+++ b/test/runtime_config.test.ts
@@ -491,19 +491,6 @@ describe('Runtime Configuration', () => {
       });
     });
 
-    it('should configure caching options', () => {
-      const cacheConfig = {
-        enableCache: true,
-        maxCacheSize: 1024 * 1024, // 1MB
-        cacheTTL: 300000, // 5 minutes
-        cacheStrategy: 'lru',
-      };
-
-      expect(cacheConfig.enableCache).toBe(true);
-      expect(cacheConfig.maxCacheSize).toBe(1048576);
-      expect(cacheConfig.cacheStrategy).toBe('lru');
-    });
-
     it('should configure memory limits', () => {
       const memoryConfig = {
         maxHeapSize: 512 * 1024 * 1024, // 512MB


### PR DESCRIPTION
Part of the v0.9.0 cleanup wave.

Removes the opt-in `enableCache` runtime result cache from `NodeBridge`. Its purity check was a regex on the function *name* (`get_*`/`read_*`/`fetch_*`/`load_*` counted as pure), and results went into `globalCache` with `persistToDisk: true` — so an opted-in user calling a changing `get_price()` could receive stale data indefinitely, surviving process restarts.

- `call()` override deleted entirely — `NodeBridge` now inherits the identical ready-then-delegate path from `BasePythonBridge`
- `isPureFunctionCandidate` / cache-key helpers removed; docs rows removed
- Codegen/IR caching (`src/tywrap.ts`, `src/core/generator.ts`) untouched
- HTTP/Pyodide bridges verified to have no equivalent path

**BREAKING CHANGE**: `enableCache` option removed (pre-1.0; v0.9 is openly breaking per #260).
Net: **−120 lines**. `npm run check:all` green.
