### PR TITLE
fix(runtime)!: serial-worker pool default and strict codec rejection of Map/Set

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ const bridge = new NodeBridge({
 
 NodeBridge is the public Node runtime bridge. It runs in single-process mode by
 default and also supports pooled execution through `minProcesses`,
-`maxProcesses`, and `maxConcurrentPerProcess`.
+`maxProcesses`, and `maxConcurrentPerProcess`. Python workers process requests
+serially, so `maxConcurrentPerProcess` defaults to `1` and lets the pool use
+another process for concurrent calls when `maxProcesses` permits it.
 
 `OptimizedNodeBridge` is now only a deprecated compatibility alias for older
 deep imports. It is not part of the package exports and should not be used in

--- a/docs/guide/runtimes/node.md
+++ b/docs/guide/runtimes/node.md
@@ -158,7 +158,7 @@ const bridge = new NodeBridge({
 | `queueTimeoutMs`          | `number`                                 | `30000`         | Queue timeout when the pool is saturated |
 | `minProcesses`            | `number`                                 | `1`             | Minimum worker count                     |
 | `maxProcesses`            | `number`                                 | `1`             | Maximum worker count                     |
-| `maxConcurrentPerProcess` | `number`                                 | `10`            | Concurrent requests per worker           |
+| `maxConcurrentPerProcess` | `number`                                 | `1`             | Concurrent requests per serial Python worker |
 | `inheritProcessEnv`       | `boolean`                                | `false`         | Pass the full parent environment through |
 | `env`                     | `Record<string, string \| undefined>`    | `{}`            | Extra subprocess env vars                |
 | `codec`                   | `CodecOptions`                           | —               | Codec validation and byte handling       |

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -1252,7 +1252,7 @@ const bridge = new NodeBridge({
 | `queueTimeoutMs`          | `number`                                 | `30000`         | Queue timeout when the pool is saturated |
 | `minProcesses`            | `number`                                 | `1`             | Minimum worker count                     |
 | `maxProcesses`            | `number`                                 | `1`             | Maximum worker count                     |
-| `maxConcurrentPerProcess` | `number`                                 | `10`            | Concurrent requests per worker           |
+| `maxConcurrentPerProcess` | `number`                                 | `1`             | Concurrent requests per serial Python worker |
 | `inheritProcessEnv`       | `boolean`                                | `false`         | Pass the full parent environment through |
 | `env`                     | `Record<string, string \| undefined>`    | `{}`            | Extra subprocess env vars                |
 | `codec`                   | `CodecOptions`                           | —               | Codec validation and byte handling       |
@@ -3216,7 +3216,7 @@ const info = await bridge.getBridgeInfo({ refresh: true });
 | `queueTimeoutMs`          | `30000`         | Wait time when the worker pool is saturated     |
 | `minProcesses`            | `1`             | Minimum worker count                            |
 | `maxProcesses`            | `1`             | Maximum worker count                            |
-| `maxConcurrentPerProcess` | `10`            | Concurrent requests per worker                  |
+| `maxConcurrentPerProcess` | `1`             | Concurrent requests per serial Python worker    |
 | `inheritProcessEnv`       | `false`         | Pass full parent env through                    |
 | `env`                     | `{}`            | Extra subprocess env vars                       |
 | `codec`                   | —               | `CodecOptions` for validation and byte handling |

--- a/docs/reference/api/index.md
+++ b/docs/reference/api/index.md
@@ -140,7 +140,7 @@ const info = await bridge.getBridgeInfo({ refresh: true });
 | `queueTimeoutMs`          | `30000`         | Wait time when the worker pool is saturated     |
 | `minProcesses`            | `1`             | Minimum worker count                            |
 | `maxProcesses`            | `1`             | Maximum worker count                            |
-| `maxConcurrentPerProcess` | `10`            | Concurrent requests per worker                  |
+| `maxConcurrentPerProcess` | `1`             | Concurrent requests per serial Python worker    |
 | `inheritProcessEnv`       | `false`         | Pass full parent env through                    |
 | `env`                     | `{}`            | Extra subprocess env vars                       |
 | `codec`                   | —               | `CodecOptions` for validation and byte handling |

--- a/src/runtime/bridge-codec.ts
+++ b/src/runtime/bridge-codec.ts
@@ -28,7 +28,7 @@ export interface CodecOptions {
   /** Max payload size in bytes. Default: 10MB */
   maxPayloadBytes?: number;
   /** How to handle bytes/bytearray. Default: 'base64' */
-  bytesHandling?: 'base64' | 'reject' | 'passthrough';
+  bytesHandling?: 'base64' | 'reject';
 }
 
 /**
@@ -88,11 +88,13 @@ function buildPath(basePath: string, key: string | number): string {
 }
 
 /**
- * Recursively check for non-string keys in objects and Maps.
+ * Recursively validate request values that JSON.stringify cannot represent
+ * without data loss, and optionally check object keys.
  * Throws BridgeCodecError with path indication if found.
  */
-function assertStringKeys(
+function assertRequestValues(
   value: unknown,
+  rejectNonStringKeys: boolean,
   path: string = '',
   visited: WeakSet<object> = new WeakSet<object>()
 ): void {
@@ -104,29 +106,28 @@ function assertStringKeys(
   }
   visited.add(value);
 
-  // Check Map instances for non-string keys
+  // JSON.stringify serializes every Map as {}, including Maps with string keys.
   if (value instanceof Map) {
-    for (const key of value.keys()) {
-      if (typeof key !== 'string') {
-        const keyDesc = typeof key === 'symbol' ? key.toString() : String(key);
-        const location = path ? ` at ${path}` : '';
-        throw new BridgeCodecError(
-          `Non-string key found in Map${location}: ${keyDesc} (${typeof key})`,
-          { codecPhase: 'encode' }
-        );
-      }
-    }
-    // Recurse into Map values
-    for (const [key, val] of value.entries()) {
-      assertStringKeys(val, buildPath(path, key), visited);
-    }
-    return;
+    const location = path ? ` at ${path}` : '';
+    throw new BridgeCodecError(
+      `Cannot encode request: Map found${location}; convert it to a plain object before sending`,
+      { codecPhase: 'encode' }
+    );
+  }
+
+  // JSON.stringify serializes every Set as {}.
+  if (value instanceof Set) {
+    const location = path ? ` at ${path}` : '';
+    throw new BridgeCodecError(
+      `Cannot encode request: Set found${location}; convert it to an array before sending`,
+      { codecPhase: 'encode' }
+    );
   }
 
   // Check arrays
   if (Array.isArray(value)) {
     for (const [index, item] of value.entries()) {
-      assertStringKeys(item, buildPath(path, index), visited);
+      assertRequestValues(item, rejectNonStringKeys, buildPath(path, index), visited);
     }
     return;
   }
@@ -134,19 +135,21 @@ function assertStringKeys(
   // Check plain objects for symbol keys
   if (isPlainObject(value)) {
     // Symbol keys are not enumerated by Object.keys, use getOwnPropertySymbols
-    const symbolKeys = Object.getOwnPropertySymbols(value);
-    const firstSymbol = symbolKeys[0];
-    if (firstSymbol !== undefined) {
-      const symbolDesc = firstSymbol.toString();
-      const location = path ? ` at ${path}` : '';
-      throw new BridgeCodecError(`Symbol key found in object${location}: ${symbolDesc}`, {
-        codecPhase: 'encode',
-      });
+    if (rejectNonStringKeys) {
+      const symbolKeys = Object.getOwnPropertySymbols(value);
+      const firstSymbol = symbolKeys[0];
+      if (firstSymbol !== undefined) {
+        const symbolDesc = firstSymbol.toString();
+        const location = path ? ` at ${path}` : '';
+        throw new BridgeCodecError(`Symbol key found in object${location}: ${symbolDesc}`, {
+          codecPhase: 'encode',
+        });
+      }
     }
 
     // Recurse into object values
     for (const [key, item] of Object.entries(value)) {
-      assertStringKeys(item, buildPath(path, key), visited);
+      assertRequestValues(item, rejectNonStringKeys, buildPath(path, key), visited);
     }
   }
 }
@@ -318,7 +321,7 @@ export class BridgeCodec {
   private readonly rejectSpecialFloats: boolean;
   private readonly rejectNonStringKeys: boolean;
   private readonly maxPayloadBytes: number;
-  private readonly bytesHandling: 'base64' | 'reject' | 'passthrough';
+  private readonly bytesHandling: 'base64' | 'reject';
   private readonly reviveValueBound: (key: string, value: unknown) => unknown;
   private static readonly base64Pattern =
     /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
@@ -515,10 +518,8 @@ export class BridgeCodec {
       );
     }
 
-    // Validate string keys if enabled
-    if (this.rejectNonStringKeys) {
-      assertStringKeys(message);
-    }
+    // Reject values JSON.stringify would silently mangle, and validate object keys.
+    assertRequestValues(message, this.rejectNonStringKeys);
 
     // Serialize to JSON with error handling
     let payload: string;
@@ -537,9 +538,6 @@ export class BridgeCodec {
               const b64 = this.toBase64(bytes);
               return { __tywrap_bytes__: true, b64 };
             }
-            case 'passthrough':
-            default:
-              return value;
           }
         }
         return value;

--- a/src/runtime/node.ts
+++ b/src/runtime/node.ts
@@ -39,7 +39,12 @@ export interface NodeBridgeOptions {
   /** Maximum number of Python processes to spawn. Default: 1 (single-process mode) */
   maxProcesses?: number;
 
-  /** Maximum concurrent requests per process. Default: 10 */
+  /**
+   * Maximum concurrent requests per process. Default: 1.
+   *
+   * Python bridge workers process JSONL requests serially, so the default lets
+   * the pool use another process for concurrent calls when one is available.
+   */
   maxConcurrentPerProcess?: number;
 
   /** Path to Python executable. Auto-detected if not specified. */
@@ -337,7 +342,7 @@ export class NodeBridge extends BasePythonBridge {
     const resolvedOptions: ResolvedOptions = {
       minProcesses,
       maxProcesses,
-      maxConcurrentPerProcess: options.maxConcurrentPerProcess ?? 10,
+      maxConcurrentPerProcess: options.maxConcurrentPerProcess ?? 1,
       pythonPath: options.pythonPath ?? venv?.pythonPath ?? getDefaultPythonPath(),
       scriptPath: resolvedScriptPath,
       virtualEnv,

--- a/src/runtime/pooled-transport.ts
+++ b/src/runtime/pooled-transport.ts
@@ -39,7 +39,7 @@ interface PooledTransportOptions {
   /** Timeout for waiting in queue (ms). Default: 30000 */
   queueTimeoutMs?: number;
 
-  /** Maximum concurrent requests per worker. Default: 10 */
+  /** Maximum concurrent requests per worker. Default: 1 */
   maxConcurrentPerWorker?: number;
 
   /**
@@ -117,7 +117,7 @@ export class PooledTransport extends DisposableBase implements Transport {
       maxWorkers: options.maxWorkers ?? 1,
       minWorkers: options.minWorkers ?? 0,
       queueTimeoutMs: options.queueTimeoutMs ?? 30000,
-      maxConcurrentPerWorker: options.maxConcurrentPerWorker ?? 10,
+      maxConcurrentPerWorker: options.maxConcurrentPerWorker ?? 1,
       onWorkerReady: options.onWorkerReady,
       onReplacementWorkerReady: options.onReplacementWorkerReady,
     };

--- a/test/bridge-codec.test.ts
+++ b/test/bridge-codec.test.ts
@@ -138,39 +138,45 @@ describe('encodeRequest - Non-String Key Rejection', () => {
     codec = new BridgeCodec({ rejectNonStringKeys: true });
   });
 
-  it('rejects Map with number keys', () => {
+  it('rejects Map with number keys before JSON.stringify can silently encode it as an object', () => {
     const map = new Map<number, string>([
       [1, 'one'],
       [2, 'two'],
     ]);
     expect(() => codec.encodeRequest({ data: map })).toThrow(BridgeCodecError);
-    expect(() => codec.encodeRequest({ data: map })).toThrow(/Non-string key.*Map/);
-    expect(() => codec.encodeRequest({ data: map })).toThrow(/1.*number/);
+    expect(() => codec.encodeRequest({ data: map })).toThrow(/Map found at data/);
+    expect(() => codec.encodeRequest({ data: map })).toThrow(/plain object/);
   });
 
   it('rejects Map with object keys', () => {
     const objKey = { id: 1 };
     const map = new Map<object, string>([[objKey, 'value']]);
     expect(() => codec.encodeRequest({ data: map })).toThrow(BridgeCodecError);
-    expect(() => codec.encodeRequest({ data: map })).toThrow(/Non-string key.*Map/);
-    expect(() => codec.encodeRequest({ data: map })).toThrow(/object/);
+    expect(() => codec.encodeRequest({ data: map })).toThrow(/Map found at data/);
   });
 
   it('rejects Map with symbol keys', () => {
     const sym = Symbol('test');
     const map = new Map<symbol, string>([[sym, 'value']]);
     expect(() => codec.encodeRequest({ data: map })).toThrow(BridgeCodecError);
-    expect(() => codec.encodeRequest({ data: map })).toThrow(/symbol/);
+    expect(() => codec.encodeRequest({ data: map })).toThrow(/Map found at data/);
   });
 
-  it('passes Map with string keys', () => {
+  it('rejects Map with string keys before JSON.stringify can silently encode it as an object', () => {
     const map = new Map<string, number>([
       ['a', 1],
       ['b', 2],
     ]);
-    // Note: JSON.stringify doesn't serialize Maps to objects by default
-    // It will serialize to {} or needs a replacer, so we just verify validation passes
-    expect(() => codec.encodeRequest({ data: map })).not.toThrow();
+    expect(() => codec.encodeRequest({ data: map })).toThrow(BridgeCodecError);
+    expect(() => codec.encodeRequest({ data: map })).toThrow(/Map found at data/);
+    expect(() => codec.encodeRequest({ data: map })).toThrow(/plain object/);
+  });
+
+  it('rejects Set values before JSON.stringify can silently encode them as an object', () => {
+    const values = new Set([1, 2, 3]);
+    expect(() => codec.encodeRequest({ data: values })).toThrow(BridgeCodecError);
+    expect(() => codec.encodeRequest({ data: values })).toThrow(/Set found at data/);
+    expect(() => codec.encodeRequest({ data: values })).toThrow(/array/);
   });
 
   it('passes plain objects with string keys', () => {
@@ -198,11 +204,11 @@ describe('encodeRequest - Non-String Key Rejection', () => {
     expect(() => codec.encodeRequest(data)).toThrow(BridgeCodecError);
   });
 
-  it('can be disabled via rejectNonStringKeys: false', () => {
+  it('still rejects Maps when rejectNonStringKeys is disabled', () => {
     const permissiveCodec = new BridgeCodec({ rejectNonStringKeys: false });
     const map = new Map<number, string>([[1, 'one']]);
-    // Validation should pass (though JSON.stringify still won't serialize Map properly)
-    expect(() => permissiveCodec.encodeRequest({ data: map })).not.toThrow();
+    expect(() => permissiveCodec.encodeRequest({ data: map })).toThrow(BridgeCodecError);
+    expect(() => permissiveCodec.encodeRequest({ data: map })).toThrow(/plain object/);
   });
 });
 
@@ -304,8 +310,8 @@ describe('encodeRequest - Serialization Errors', () => {
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe('encodeRequest - Bytes Handling', () => {
-  it('encodes Uint8Array to base64 with marker (default)', () => {
-    const codec = new BridgeCodec({ bytesHandling: 'base64' });
+  it('keeps Uint8Array base64 encoding unchanged by default', () => {
+    const codec = new BridgeCodec();
     const bytes = new Uint8Array([72, 101, 108, 108, 111]); // "Hello"
     const payload = codec.encodeRequest({ data: bytes });
     const parsed = JSON.parse(payload);
@@ -328,16 +334,6 @@ describe('encodeRequest - Bytes Handling', () => {
     expect(() => codec.encodeRequest({ data: bytes })).toThrow(BridgeCodecError);
     expect(() => codec.encodeRequest({ data: bytes })).toThrow(/binary data found/);
     expect(() => codec.encodeRequest({ data: bytes })).toThrow(/bytesHandling: reject/);
-  });
-
-  it('passes through binary data when bytesHandling is passthrough', () => {
-    const codec = new BridgeCodec({ bytesHandling: 'passthrough' });
-    const bytes = new Uint8Array([1, 2, 3]);
-    // passthrough means we don't transform, but JSON.stringify will still fail
-    // to serialize Uint8Array properly (it becomes an object with indices)
-    const payload = codec.encodeRequest({ data: bytes });
-    const parsed = JSON.parse(payload);
-    expect(parsed.data).toEqual({ '0': 1, '1': 2, '2': 3 });
   });
 });
 

--- a/test/runtime_node.test.ts
+++ b/test/runtime_node.test.ts
@@ -939,6 +939,24 @@ def get_bad():
     );
 
     it.skipIf(!PYTHON_OK)(
+      'uses both workers for two concurrent calls when maxProcesses is 2 by default',
+      async () => {
+        bridge = new NodeBridge({ scriptPath, maxProcesses: 2, timeoutMs: defaultTimeoutMs });
+        try {
+          const processIds = await Promise.all([
+            bridge.call<number>('os', 'getpid', []),
+            bridge.call<number>('os', 'getpid', []),
+          ]);
+
+          expect(new Set(processIds)).toHaveLength(2);
+        } finally {
+          await bridge.dispose();
+        }
+      },
+      testTimeout
+    );
+
+    it.skipIf(!PYTHON_OK)(
       'should handle process crashes gracefully',
       async () => {
         bridge = new NodeBridge({ scriptPath, timeoutMs: defaultTimeoutMs });


### PR DESCRIPTION
Part of the v0.9.0 cleanup wave. Two audit-verified correctness fixes:

**1. Pool default gives real parallelism.** `runtime/python_bridge.py` `main()` is a strictly serial `for line in sys.stdin` loop, but `maxConcurrentPerProcess` defaulted to 10 — the pool piled 10 in-flight requests onto one serial worker before spawning a second, so `maxProcesses > 1` provided no parallelism until 11 concurrent calls, and queued requests burned timeout budget. Default is now **1**; explicit higher values still allowed. Regression test asserts two concurrent calls with `maxProcesses: 2` use two distinct PIDs.

**2. Codec rejects what JSON.stringify silently destroys.** `assertStringKeys` explicitly *permitted* string-keyed Maps, then `JSON.stringify` serialized every Map (and Set) as `{}` — arguments arrived in Python silently empty. Maps and Sets are now rejected at validation with a convert-to-plain-object/array error (unconditional — this is always data loss, so it isn't gated behind `rejectNonStringKeys`). The lossy `bytesHandling: 'passthrough'` mode (TypedArrays → numeric-key objects) is removed; `base64` default unchanged.

**BREAKING CHANGE**: `maxConcurrentPerProcess` default 10 → 1; Map/Set arguments now throw instead of silently encoding as `{}`; `bytesHandling: 'passthrough'` removed.
`npm run check:all` green.
