### PR TITLE
docs: describe type coverage accurately in docs and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![Docs](https://img.shields.io/badge/docs-bbopen.github.io%2Ftywrap-blue)](https://bbopen.github.io/tywrap)
 
-TypeScript wrapper for Python libraries with full type safety.
+TypeScript bindings for Python libraries, with precise types for fully
+annotated, in-module, serializable Python returns and fallbacks where tywrap
+cannot resolve a type.
 
 > **⚠️ Experimental** — APIs may change before v1.0.0. See the
 > [releases page](https://github.com/bbopen/tywrap/releases) for breaking
@@ -17,13 +19,15 @@ TypeScript wrapper for Python libraries with full type safety.
 
 ## Features
 
-- **Full Type Safety** - TypeScript definitions generated from Python source
-  analysis
+- **Accurate Type Coverage** - Precise TypeScript types for fully annotated,
+  in-module, serializable Python returns, with fallbacks where resolution is not
+  possible
 - **Development Hot Reload** - Real Node watch sessions regenerate wrappers and
   swap the active bridge without re-importing generated modules
 - **Generic-Aware Declarations** - Preserves simple `TypeVar` and callable
   `ParamSpec` generics in generated `.ts` and `.d.ts` output
-- **Multi-Runtime** - Node.js (subprocess) and browsers (Pyodide)
+- **Multi-Runtime** - Node.js and Bun (subprocess), browsers (Pyodide), and
+  experimental, untested-in-CI Deno subprocess support
 - **Rich Data Types** - numpy, pandas, scipy, torch, sklearn, and stdlib types
 - **Efficient Serialization** - Apache Arrow binary format with JSON fallback
 - **Large-Payload Transport** - the Node subprocess bridge chunks results that
@@ -42,7 +46,8 @@ TypeScript wrapper for Python libraries with full type safety.
 
 ## Requirements
 
-- Node.js 20+ (or Bun 1.1+ / Deno 1.46+)
+- Node.js 20+ (or Bun 1.1+ / Deno 1.46+; Deno subprocess support is experimental
+  and untested in CI)
 - Python 3.10+ with `tywrap-ir`:
 
   ```bash
@@ -121,7 +126,8 @@ Raise `codec.maxPayloadBytes` to carry genuinely large results. You can still
 bound JSONL traffic explicitly with `TYWRAP_CODEC_MAX_BYTES` (responses) and
 `TYWRAP_REQUEST_MAX_BYTES` (requests). See the
 [transport framing](https://bbopen.github.io/tywrap/transport-framing) and
-[capability matrix](https://bbopen.github.io/tywrap/transport-capabilities) docs.
+[capability matrix](https://bbopen.github.io/tywrap/transport-capabilities)
+docs.
 
 ## Development Hot Reload
 
@@ -159,6 +165,8 @@ await bridge.init();
 ```
 
 ### Deno / Bun
+
+Deno subprocess support is experimental and untested in CI.
 
 ```typescript
 import { NodeBridge } from 'npm:tywrap'; // Deno
@@ -218,6 +226,11 @@ registerArrowDecoder(bytes => tableFromIPC(bytes));
 - [API Reference](https://bbopen.github.io/tywrap/reference/api/)
 - [Troubleshooting](https://bbopen.github.io/tywrap/troubleshooting/)
 - [Roadmap](./ROADMAP.md)
+
+## Security
+
+See [SECURITY.md](./SECURITY.md) for the bridge trust model and vulnerability
+reporting.
 
 ## Contributing
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,8 +1,9 @@
-import { defineConfig } from 'vitepress'
+import { defineConfig } from 'vitepress';
 
 export default defineConfig({
   title: 'tywrap',
-  description: 'Generate type-safe TypeScript wrappers for any Python library — Node.js, Deno, Bun, and browsers via Pyodide.',
+  description:
+    'Generate TypeScript bindings with precise types for fully annotated, in-module, serializable Python returns, with fallbacks where tywrap cannot resolve a type.',
   base: '/tywrap/',
   appearance: 'force-dark',
   cleanUrls: true,
@@ -53,15 +54,11 @@ export default defineConfig({
       },
       {
         text: 'Examples',
-        items: [
-          { text: 'Quick Examples', link: '/examples/' },
-        ],
+        items: [{ text: 'Quick Examples', link: '/examples/' }],
       },
       {
         text: 'Help',
-        items: [
-          { text: 'Troubleshooting', link: '/troubleshooting/' },
-        ],
+        items: [{ text: 'Troubleshooting', link: '/troubleshooting/' }],
       },
     ],
 
@@ -69,9 +66,7 @@ export default defineConfig({
       provider: 'local',
     },
 
-    socialLinks: [
-      { icon: 'github', link: 'https://github.com/bbopen/tywrap' },
-    ],
+    socialLinks: [{ icon: 'github', link: 'https://github.com/bbopen/tywrap' }],
 
     editLink: {
       pattern: 'https://github.com/bbopen/tywrap/edit/main/docs/:path',
@@ -83,4 +78,4 @@ export default defineConfig({
       copyright: 'Copyright © tywrap contributors',
     },
   },
-})
+});

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -5,7 +5,8 @@ TypeScript wrapper for a Python library.
 
 ## Prerequisites
 
-- Node.js ≥20.0.0, Deno ≥1.46.0, or Bun ≥1.1.0
+- Node.js ≥20.0.0, Bun ≥1.1.0, or Deno ≥1.46.0 (Deno subprocess support is
+  experimental and untested in CI)
 - Python 3.10+ with target libraries installed
 - Basic TypeScript knowledge
 
@@ -105,7 +106,7 @@ import * as math from './generated/math.generated.js';
 const bridge = new NodeBridge({ pythonPath: 'python3' });
 setRuntimeBridge(bridge);
 
-// Use with full type safety
+// Types are precise where tywrap can resolve them.
 async function example() {
   const result = await math.sqrt(16); // TypeScript knows this returns Promise<number>
   const power = await math.pow(2, 3); // Full autocompletion and type checking
@@ -296,9 +297,8 @@ const session = await startNodeWatchSession({
 });
 ```
 
-For Pyodide, use `createBridgeReloader(...)` from `tywrap/dev` for manual
-bridge replacement. For HTTP, restart or redeploy the remote server outside
-tywrap.
+For Pyodide, use `createBridgeReloader(...)` from `tywrap/dev` for manual bridge
+replacement. For HTTP, restart or redeploy the remote server outside tywrap.
 
 `startNodeWatchSession(...)` watches local package directories as directory
 trees, refreshes those trees when nested directories change, and keeps the last

--- a/docs/guide/runtimes/comparison.md
+++ b/docs/guide/runtimes/comparison.md
@@ -4,25 +4,25 @@ tywrap supports five runtime configurations. Choose based on your environment.
 
 ## Feature Matrix
 
-| Feature | Node.js | Bun | Deno (local) | Browser (Pyodide) | HTTP |
-|---------|:-------:|:---:|:------------:|:-----------------:|:----:|
-| Python subprocess | ✅ | ✅ | ✅ | ❌ | ❌ |
-| Deno Deploy / serverless | ❌ | ❌ | ❌ | ✅ | ✅ |
-| Apache Arrow transport | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Virtual environment support | ✅ | ✅ | ✅ | ❌ | Server-side |
-| Process pooling (experimental) | ✅ | ✅ | ✅ | ❌ | ❌ |
-| Development hot reload | ✅ | ❌ | ❌ | Manual bridge reload | External |
-| Tested in CI | ✅ | ✅ | Mocked | ✅ | ✅ |
+| Feature                        | Node.js | Bun | Deno (experimental) |  Browser (Pyodide)   |    HTTP     |
+| ------------------------------ | :-----: | :-: | :-----------------: | :------------------: | :---------: |
+| Python subprocess              |   ✅    | ✅  |         ✅          |          ❌          |     ❌      |
+| Deno Deploy / serverless       |   ❌    | ❌  |         ❌          |          ✅          |     ✅      |
+| Apache Arrow transport         |   ✅    | ✅  |         ✅          |          ✅          |     ✅      |
+| Virtual environment support    |   ✅    | ✅  |         ✅          |          ❌          | Server-side |
+| Process pooling (experimental) |   ✅    | ✅  |         ✅          |          ❌          |     ❌      |
+| Development hot reload         |   ✅    | ❌  |         ❌          | Manual bridge reload |  External   |
+| Tested in CI                   |   ✅    | ✅  |    ❌ (untested)    |          ✅          |     ✅      |
 
 ## Import Paths
 
-| Runtime | Import |
-|---------|--------|
-| Node.js | `import { NodeBridge } from 'tywrap/node'` |
-| Bun | `import { NodeBridge } from 'tywrap/node'` |
-| Deno | `import { NodeBridge } from 'npm:tywrap'` |
-| Browser | `import { PyodideBridge } from 'tywrap/pyodide'` |
-| HTTP | `import { HttpBridge } from 'tywrap/http'` |
+| Runtime                       | Import                                           |
+| ----------------------------- | ------------------------------------------------ |
+| Node.js                       | `import { NodeBridge } from 'tywrap/node'`       |
+| Bun                           | `import { NodeBridge } from 'tywrap/node'`       |
+| Deno (experimental, untested) | `import { NodeBridge } from 'npm:tywrap'`        |
+| Browser                       | `import { PyodideBridge } from 'tywrap/pyodide'` |
+| HTTP                          | `import { HttpBridge } from 'tywrap/http'`       |
 
 ## Decision Guide
 
@@ -30,7 +30,7 @@ tywrap supports five runtime configurations. Choose based on your environment.
 Do you need subprocess-based Python execution?
 ├── Yes → Does your environment support subprocess?
 │   ├── Node.js or Bun → Use NodeBridge (import from 'tywrap/node' or 'tywrap')
-│   ├── Deno (local) → Use NodeBridge with --allow-run=python3
+│   ├── Deno (experimental, untested) → Use NodeBridge with --allow-run=python3
 │   └── Deno Deploy / serverless → Continue ↓
 └── No (browser, edge, serverless) →
     ├── Can you load ~50MB WebAssembly? → Use PyodideBridge
@@ -39,8 +39,8 @@ Do you need subprocess-based Python execution?
 
 ## Bridge Reference
 
-| Bridge | Export | Guide |
-|--------|--------|-------|
-| `NodeBridge` | `tywrap/node` | [Node.js](./node) · [Bun](./bun) · [Deno](./deno) |
-| `PyodideBridge` | `tywrap/pyodide` | [Browser](./browser) |
-| `HttpBridge` | `tywrap/http` | [HTTP](./http) |
+| Bridge          | Export           | Guide                                             |
+| --------------- | ---------------- | ------------------------------------------------- |
+| `NodeBridge`    | `tywrap/node`    | [Node.js](./node) · [Bun](./bun) · [Deno](./deno) |
+| `PyodideBridge` | `tywrap/pyodide` | [Browser](./browser)                              |
+| `HttpBridge`    | `tywrap/http`    | [HTTP](./http)                                    |

--- a/docs/guide/runtimes/deno.md
+++ b/docs/guide/runtimes/deno.md
@@ -1,14 +1,20 @@
 # Deno Runtime Guide
 
-tywrap works with [Deno](https://deno.land/) 1.46+ using the same `NodeBridge` as Node.js. Deno requires the `npm:` prefix for npm imports.
+tywrap's Deno subprocess support is experimental and untested in CI. It uses the
+same `NodeBridge` as Node.js, and Deno requires the `npm:` prefix for npm
+imports.
 
 ## ⚠️ Deno Deploy Limitation
 
-**Deno Deploy does NOT support subprocess execution.** Because `NodeBridge` spawns a Python subprocess, it cannot run in Deno Deploy.
+**Deno Deploy does NOT support subprocess execution.** Because `NodeBridge`
+spawns a Python subprocess, it cannot run in Deno Deploy.
 
 **Alternatives for Deno Deploy:**
-- Use [`PyodideBridge`](/guide/runtimes/browser) — runs Python in-browser via WebAssembly (no subprocess)
-- Use [`HttpBridge`](/guide/runtimes/http) — connects to a remote Python server over HTTP
+
+- Use [`PyodideBridge`](/guide/runtimes/browser) — runs Python in-browser via
+  WebAssembly (no subprocess)
+- Use [`HttpBridge`](/guide/runtimes/http) — connects to a remote Python server
+  over HTTP
 
 ## Installation
 
@@ -23,10 +29,12 @@ pip install tywrap-ir
 import { NodeBridge } from 'npm:tywrap';
 import { setRuntimeBridge } from 'npm:tywrap/runtime';
 
-setRuntimeBridge(new NodeBridge({
-  pythonPath: 'python3',
-  timeoutMs: 30000,
-}));
+setRuntimeBridge(
+  new NodeBridge({
+    pythonPath: 'python3',
+    timeoutMs: 30000,
+  })
+);
 ```
 
 ## Required Permissions
@@ -41,11 +49,11 @@ deno run \
   your-script.ts
 ```
 
-| Flag | Reason |
-|------|--------|
-| `--allow-run=python3` | Spawn the Python subprocess |
-| `--allow-read` | Read Python scripts and config files |
-| `--allow-env` | Read `TYWRAP_*` and `PATH` environment variables |
+| Flag                  | Reason                                           |
+| --------------------- | ------------------------------------------------ |
+| `--allow-run=python3` | Spawn the Python subprocess                      |
+| `--allow-read`        | Read Python scripts and config files             |
+| `--allow-env`         | Read `TYWRAP_*` and `PATH` environment variables |
 
 ## Type Checking
 
@@ -55,24 +63,29 @@ deno check src/index.ts
 
 ## Configuration Options
 
-See the [Node.js guide](./node) for the full `NodeBridgeOptions` reference — all options work identically in Deno.
+See the [Node.js guide](./node) for the full `NodeBridgeOptions` reference — all
+options work identically in Deno.
 
 ## When to Use Each Bridge in Deno
 
-| Scenario | Bridge | Notes |
-|----------|--------|-------|
-| Local Deno script | `NodeBridge` | Needs `--allow-run` |
-| Deno Deploy | `PyodideBridge` | WebAssembly, no subprocess |
-| Deno Deploy + heavy Python libs | `HttpBridge` | Python runs on a separate server |
+| Scenario                        | Bridge          | Notes                            |
+| ------------------------------- | --------------- | -------------------------------- |
+| Local Deno script               | `NodeBridge`    | Needs `--allow-run`              |
+| Deno Deploy                     | `PyodideBridge` | WebAssembly, no subprocess       |
+| Deno Deploy + heavy Python libs | `HttpBridge`    | Python runs on a separate server |
 
 ## Environment Variables
 
-The same `TYWRAP_*` env vars work under Deno. See the [environment variables reference](/reference/env-vars).
+The same `TYWRAP_*` env vars work under Deno. See the
+[environment variables reference](/reference/env-vars).
 
 ## Troubleshooting
 
-**`PermissionDenied: Requires run access to "python3"`** — Add `--allow-run=python3` to your `deno run` command.
+**`PermissionDenied: Requires run access to "python3"`** — Add
+`--allow-run=python3` to your `deno run` command.
 
-**`NotSupported: Subprocess access is not allowed`** — You are running in Deno Deploy. Switch to [`PyodideBridge`](/guide/runtimes/browser) or [`HttpBridge`](/guide/runtimes/http).
+**`NotSupported: Subprocess access is not allowed`** — You are running in Deno
+Deploy. Switch to [`PyodideBridge`](/guide/runtimes/browser) or
+[`HttpBridge`](/guide/runtimes/http).
 
 See the [Node.js troubleshooting guide](./node) for additional patterns.

--- a/docs/guide/runtimes/node.md
+++ b/docs/guide/runtimes/node.md
@@ -18,8 +18,7 @@ The Node.js runtime:
 ## Bridge Selection
 
 - **NodeBridge (default)**: the public Node bridge. It supports both
-  single-process execution and pooled execution through its constructor
-  options.
+  single-process execution and pooled execution through its constructor options.
 - **OptimizedNodeBridge**: deprecated compatibility alias for older deep
   imports. It is not part of the package exports and should not be used in new
   code.
@@ -29,8 +28,8 @@ stderr buffering.
 
 ## Development Hot Reload
 
-Node hot reload in tywrap means wrapper regeneration plus bridge replacement.
-It lives in `tywrap/dev`, not in `tywrap.config.*`.
+Node hot reload in tywrap means wrapper regeneration plus bridge replacement. It
+lives in `tywrap/dev`, not in `tywrap.config.*`.
 
 ```typescript
 import { startNodeWatchSession } from 'tywrap/dev';
@@ -148,27 +147,27 @@ const bridge = new NodeBridge({
 });
 ```
 
-| Option                    | Type                                     | Default         | Description                              |
-| ------------------------- | ---------------------------------------- | --------------- | ---------------------------------------- |
-| `pythonPath`              | `string`                                 | auto-detect     | Path to the Python executable            |
-| `scriptPath`              | `string`                                 | built-in bridge | Custom `python_bridge.py` path           |
-| `virtualEnv`              | `string`                                 | —               | Virtual environment root                 |
-| `cwd`                     | `string`                                 | `process.cwd()` | Working directory for the subprocess     |
-| `timeoutMs`               | `number`                                 | `30000`         | Per-call timeout                         |
-| `queueTimeoutMs`          | `number`                                 | `30000`         | Queue timeout when the pool is saturated |
-| `minProcesses`            | `number`                                 | `1`             | Minimum worker count                     |
-| `maxProcesses`            | `number`                                 | `1`             | Maximum worker count                     |
-| `maxConcurrentPerProcess` | `number`                                 | `1`             | Concurrent requests per serial Python worker |
-| `inheritProcessEnv`       | `boolean`                                | `false`         | Pass the full parent environment through |
-| `env`                     | `Record<string, string \| undefined>`    | `{}`            | Extra subprocess env vars                |
-| `codec`                   | `CodecOptions`                           | —               | Codec validation and byte handling       |
-| `warmupCommands`          | `Array<{ module, functionName, args? }>` | `[]`            | Commands to run when each worker starts  |
+| Option                    | Type                                     | Default         | Description                                                                             |
+| ------------------------- | ---------------------------------------- | --------------- | --------------------------------------------------------------------------------------- |
+| `pythonPath`              | `string`                                 | auto-detect     | Path to the Python executable                                                           |
+| `scriptPath`              | `string`                                 | built-in bridge | Custom `python_bridge.py` path                                                          |
+| `virtualEnv`              | `string`                                 | —               | Virtual environment root                                                                |
+| `cwd`                     | `string`                                 | `process.cwd()` | Working directory for the subprocess                                                    |
+| `timeoutMs`               | `number`                                 | `30000`         | Per-call timeout                                                                        |
+| `queueTimeoutMs`          | `number`                                 | `30000`         | Queue timeout when the pool is saturated                                                |
+| `minProcesses`            | `number`                                 | `1`             | Minimum worker count                                                                    |
+| `maxProcesses`            | `number`                                 | `1`             | Maximum worker count                                                                    |
+| `maxConcurrentPerProcess` | `number`                                 | `1`             | Concurrent requests per serial Python worker; use more worker processes for concurrency |
+| `inheritProcessEnv`       | `boolean`                                | `false`         | Pass the full parent environment through                                                |
+| `env`                     | `Record<string, string \| undefined>`    | `{}`            | Extra subprocess env vars                                                               |
+| `codec`                   | `CodecOptions`                           | —               | Codec validation and byte handling                                                      |
+| `warmupCommands`          | `Array<{ module, functionName, args? }>` | `[]`            | Commands to run when each worker starts                                                 |
 
 Deprecated compatibility fields still exist on the interface: `maxIdleTime`,
 `maxRequestsPerProcess`, `enableJsonFallback`, and `maxLineLength`. Avoid them
-in new code.
-By default, the subprocess environment is minimal (PATH/PYTHON*/TYWRAP\_* only).
-Set `inheritProcessEnv: true` to pass through the full environment when needed.
+in new code. By default, the subprocess environment is minimal
+(PATH/PYTHON*/TYWRAP\_* only). Set `inheritProcessEnv: true` to pass through the
+full environment when needed.
 
 ## Python Environment Setup
 

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -64,7 +64,8 @@ TypeScript wrapper for a Python library.
 
 ## Prerequisites
 
-- Node.js ≥20.0.0, Deno ≥1.46.0, or Bun ≥1.1.0
+- Node.js ≥20.0.0, Bun ≥1.1.0, or Deno ≥1.46.0 (Deno subprocess support is
+  experimental and untested in CI)
 - Python 3.10+ with target libraries installed
 - Basic TypeScript knowledge
 
@@ -164,7 +165,7 @@ import * as math from './generated/math.generated.js';
 const bridge = new NodeBridge({ pythonPath: 'python3' });
 setRuntimeBridge(bridge);
 
-// Use with full type safety
+// Types are precise where tywrap can resolve them.
 async function example() {
   const result = await math.sqrt(16); // TypeScript knows this returns Promise<number>
   const power = await math.pow(2, 3); // Full autocompletion and type checking
@@ -355,9 +356,8 @@ const session = await startNodeWatchSession({
 });
 ```
 
-For Pyodide, use `createBridgeReloader(...)` from `tywrap/dev` for manual
-bridge replacement. For HTTP, restart or redeploy the remote server outside
-tywrap.
+For Pyodide, use `createBridgeReloader(...)` from `tywrap/dev` for manual bridge
+replacement. For HTTP, restart or redeploy the remote server outside tywrap.
 
 `startNodeWatchSession(...)` watches local package directories as directory
 trees, refreshes those trees when nested directories change, and keeps the last
@@ -1048,25 +1048,25 @@ tywrap supports five runtime configurations. Choose based on your environment.
 
 ## Feature Matrix
 
-| Feature | Node.js | Bun | Deno (local) | Browser (Pyodide) | HTTP |
-|---------|:-------:|:---:|:------------:|:-----------------:|:----:|
-| Python subprocess | ✅ | ✅ | ✅ | ❌ | ❌ |
-| Deno Deploy / serverless | ❌ | ❌ | ❌ | ✅ | ✅ |
-| Apache Arrow transport | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Virtual environment support | ✅ | ✅ | ✅ | ❌ | Server-side |
-| Process pooling (experimental) | ✅ | ✅ | ✅ | ❌ | ❌ |
-| Development hot reload | ✅ | ❌ | ❌ | Manual bridge reload | External |
-| Tested in CI | ✅ | ✅ | Mocked | ✅ | ✅ |
+| Feature                        | Node.js | Bun | Deno (experimental) |  Browser (Pyodide)   |    HTTP     |
+| ------------------------------ | :-----: | :-: | :-----------------: | :------------------: | :---------: |
+| Python subprocess              |   ✅    | ✅  |         ✅          |          ❌          |     ❌      |
+| Deno Deploy / serverless       |   ❌    | ❌  |         ❌          |          ✅          |     ✅      |
+| Apache Arrow transport         |   ✅    | ✅  |         ✅          |          ✅          |     ✅      |
+| Virtual environment support    |   ✅    | ✅  |         ✅          |          ❌          | Server-side |
+| Process pooling (experimental) |   ✅    | ✅  |         ✅          |          ❌          |     ❌      |
+| Development hot reload         |   ✅    | ❌  |         ❌          | Manual bridge reload |  External   |
+| Tested in CI                   |   ✅    | ✅  |    ❌ (untested)    |          ✅          |     ✅      |
 
 ## Import Paths
 
-| Runtime | Import |
-|---------|--------|
-| Node.js | `import { NodeBridge } from 'tywrap/node'` |
-| Bun | `import { NodeBridge } from 'tywrap/node'` |
-| Deno | `import { NodeBridge } from 'npm:tywrap'` |
-| Browser | `import { PyodideBridge } from 'tywrap/pyodide'` |
-| HTTP | `import { HttpBridge } from 'tywrap/http'` |
+| Runtime                       | Import                                           |
+| ----------------------------- | ------------------------------------------------ |
+| Node.js                       | `import { NodeBridge } from 'tywrap/node'`       |
+| Bun                           | `import { NodeBridge } from 'tywrap/node'`       |
+| Deno (experimental, untested) | `import { NodeBridge } from 'npm:tywrap'`        |
+| Browser                       | `import { PyodideBridge } from 'tywrap/pyodide'` |
+| HTTP                          | `import { HttpBridge } from 'tywrap/http'`       |
 
 ## Decision Guide
 
@@ -1074,7 +1074,7 @@ tywrap supports five runtime configurations. Choose based on your environment.
 Do you need subprocess-based Python execution?
 ├── Yes → Does your environment support subprocess?
 │   ├── Node.js or Bun → Use NodeBridge (import from 'tywrap/node' or 'tywrap')
-│   ├── Deno (local) → Use NodeBridge with --allow-run=python3
+│   ├── Deno (experimental, untested) → Use NodeBridge with --allow-run=python3
 │   └── Deno Deploy / serverless → Continue ↓
 └── No (browser, edge, serverless) →
     ├── Can you load ~50MB WebAssembly? → Use PyodideBridge
@@ -1083,11 +1083,11 @@ Do you need subprocess-based Python execution?
 
 ## Bridge Reference
 
-| Bridge | Export | Guide |
-|--------|--------|-------|
-| `NodeBridge` | `tywrap/node` | [Node.js](https://bbopen.github.io/tywrap/guide/runtimes/node) · [Bun](https://bbopen.github.io/tywrap/guide/runtimes/bun) · [Deno](https://bbopen.github.io/tywrap/guide/runtimes/deno) |
-| `PyodideBridge` | `tywrap/pyodide` | [Browser](https://bbopen.github.io/tywrap/guide/runtimes/browser) |
-| `HttpBridge` | `tywrap/http` | [HTTP](https://bbopen.github.io/tywrap/guide/runtimes/http) |
+| Bridge          | Export           | Guide                                             |
+| --------------- | ---------------- | ------------------------------------------------- |
+| `NodeBridge`    | `tywrap/node`    | [Node.js](https://bbopen.github.io/tywrap/guide/runtimes/node) · [Bun](https://bbopen.github.io/tywrap/guide/runtimes/bun) · [Deno](https://bbopen.github.io/tywrap/guide/runtimes/deno) |
+| `PyodideBridge` | `tywrap/pyodide` | [Browser](https://bbopen.github.io/tywrap/guide/runtimes/browser)                              |
+| `HttpBridge`    | `tywrap/http`    | [HTTP](https://bbopen.github.io/tywrap/guide/runtimes/http)                                    |
 
 ---
 
@@ -1112,8 +1112,7 @@ The Node.js runtime:
 ## Bridge Selection
 
 - **NodeBridge (default)**: the public Node bridge. It supports both
-  single-process execution and pooled execution through its constructor
-  options.
+  single-process execution and pooled execution through its constructor options.
 - **OptimizedNodeBridge**: deprecated compatibility alias for older deep
   imports. It is not part of the package exports and should not be used in new
   code.
@@ -1123,8 +1122,8 @@ stderr buffering.
 
 ## Development Hot Reload
 
-Node hot reload in tywrap means wrapper regeneration plus bridge replacement.
-It lives in `tywrap/dev`, not in `tywrap.config.*`.
+Node hot reload in tywrap means wrapper regeneration plus bridge replacement. It
+lives in `tywrap/dev`, not in `tywrap.config.*`.
 
 ```typescript
 import { startNodeWatchSession } from 'tywrap/dev';
@@ -1242,27 +1241,27 @@ const bridge = new NodeBridge({
 });
 ```
 
-| Option                    | Type                                     | Default         | Description                              |
-| ------------------------- | ---------------------------------------- | --------------- | ---------------------------------------- |
-| `pythonPath`              | `string`                                 | auto-detect     | Path to the Python executable            |
-| `scriptPath`              | `string`                                 | built-in bridge | Custom `python_bridge.py` path           |
-| `virtualEnv`              | `string`                                 | —               | Virtual environment root                 |
-| `cwd`                     | `string`                                 | `process.cwd()` | Working directory for the subprocess     |
-| `timeoutMs`               | `number`                                 | `30000`         | Per-call timeout                         |
-| `queueTimeoutMs`          | `number`                                 | `30000`         | Queue timeout when the pool is saturated |
-| `minProcesses`            | `number`                                 | `1`             | Minimum worker count                     |
-| `maxProcesses`            | `number`                                 | `1`             | Maximum worker count                     |
-| `maxConcurrentPerProcess` | `number`                                 | `1`             | Concurrent requests per serial Python worker |
-| `inheritProcessEnv`       | `boolean`                                | `false`         | Pass the full parent environment through |
-| `env`                     | `Record<string, string \| undefined>`    | `{}`            | Extra subprocess env vars                |
-| `codec`                   | `CodecOptions`                           | —               | Codec validation and byte handling       |
-| `warmupCommands`          | `Array<{ module, functionName, args? }>` | `[]`            | Commands to run when each worker starts  |
+| Option                    | Type                                     | Default         | Description                                                                             |
+| ------------------------- | ---------------------------------------- | --------------- | --------------------------------------------------------------------------------------- |
+| `pythonPath`              | `string`                                 | auto-detect     | Path to the Python executable                                                           |
+| `scriptPath`              | `string`                                 | built-in bridge | Custom `python_bridge.py` path                                                          |
+| `virtualEnv`              | `string`                                 | —               | Virtual environment root                                                                |
+| `cwd`                     | `string`                                 | `process.cwd()` | Working directory for the subprocess                                                    |
+| `timeoutMs`               | `number`                                 | `30000`         | Per-call timeout                                                                        |
+| `queueTimeoutMs`          | `number`                                 | `30000`         | Queue timeout when the pool is saturated                                                |
+| `minProcesses`            | `number`                                 | `1`             | Minimum worker count                                                                    |
+| `maxProcesses`            | `number`                                 | `1`             | Maximum worker count                                                                    |
+| `maxConcurrentPerProcess` | `number`                                 | `1`             | Concurrent requests per serial Python worker; use more worker processes for concurrency |
+| `inheritProcessEnv`       | `boolean`                                | `false`         | Pass the full parent environment through                                                |
+| `env`                     | `Record<string, string \| undefined>`    | `{}`            | Extra subprocess env vars                                                               |
+| `codec`                   | `CodecOptions`                           | —               | Codec validation and byte handling                                                      |
+| `warmupCommands`          | `Array<{ module, functionName, args? }>` | `[]`            | Commands to run when each worker starts                                                 |
 
 Deprecated compatibility fields still exist on the interface: `maxIdleTime`,
 `maxRequestsPerProcess`, `enableJsonFallback`, and `maxLineLength`. Avoid them
-in new code.
-By default, the subprocess environment is minimal (PATH/PYTHON*/TYWRAP\_* only).
-Set `inheritProcessEnv: true` to pass through the full environment when needed.
+in new code. By default, the subprocess environment is minimal
+(PATH/PYTHON*/TYWRAP\_* only). Set `inheritProcessEnv: true` to pass through the
+full environment when needed.
 
 ## Python Environment Setup
 
@@ -1857,15 +1856,21 @@ See the [Node.js troubleshooting guide](https://bbopen.github.io/tywrap/guide/ru
 <!-- Source: docs/guide/runtimes/deno.md -->
 # Deno Runtime Guide
 
-tywrap works with [Deno](https://deno.land/) 1.46+ using the same `NodeBridge` as Node.js. Deno requires the `npm:` prefix for npm imports.
+tywrap's Deno subprocess support is experimental and untested in CI. It uses the
+same `NodeBridge` as Node.js, and Deno requires the `npm:` prefix for npm
+imports.
 
 ## ⚠️ Deno Deploy Limitation
 
-**Deno Deploy does NOT support subprocess execution.** Because `NodeBridge` spawns a Python subprocess, it cannot run in Deno Deploy.
+**Deno Deploy does NOT support subprocess execution.** Because `NodeBridge`
+spawns a Python subprocess, it cannot run in Deno Deploy.
 
 **Alternatives for Deno Deploy:**
-- Use [`PyodideBridge`](https://bbopen.github.io/tywrap/guide/runtimes/browser) — runs Python in-browser via WebAssembly (no subprocess)
-- Use [`HttpBridge`](https://bbopen.github.io/tywrap/guide/runtimes/http) — connects to a remote Python server over HTTP
+
+- Use [`PyodideBridge`](https://bbopen.github.io/tywrap/guide/runtimes/browser) — runs Python in-browser via
+  WebAssembly (no subprocess)
+- Use [`HttpBridge`](https://bbopen.github.io/tywrap/guide/runtimes/http) — connects to a remote Python server
+  over HTTP
 
 ## Installation
 
@@ -1880,10 +1885,12 @@ pip install tywrap-ir
 import { NodeBridge } from 'npm:tywrap';
 import { setRuntimeBridge } from 'npm:tywrap/runtime';
 
-setRuntimeBridge(new NodeBridge({
-  pythonPath: 'python3',
-  timeoutMs: 30000,
-}));
+setRuntimeBridge(
+  new NodeBridge({
+    pythonPath: 'python3',
+    timeoutMs: 30000,
+  })
+);
 ```
 
 ## Required Permissions
@@ -1898,11 +1905,11 @@ deno run \
   your-script.ts
 ```
 
-| Flag | Reason |
-|------|--------|
-| `--allow-run=python3` | Spawn the Python subprocess |
-| `--allow-read` | Read Python scripts and config files |
-| `--allow-env` | Read `TYWRAP_*` and `PATH` environment variables |
+| Flag                  | Reason                                           |
+| --------------------- | ------------------------------------------------ |
+| `--allow-run=python3` | Spawn the Python subprocess                      |
+| `--allow-read`        | Read Python scripts and config files             |
+| `--allow-env`         | Read `TYWRAP_*` and `PATH` environment variables |
 
 ## Type Checking
 
@@ -1912,25 +1919,30 @@ deno check src/index.ts
 
 ## Configuration Options
 
-See the [Node.js guide](https://bbopen.github.io/tywrap/guide/runtimes/node) for the full `NodeBridgeOptions` reference — all options work identically in Deno.
+See the [Node.js guide](https://bbopen.github.io/tywrap/guide/runtimes/node) for the full `NodeBridgeOptions` reference — all
+options work identically in Deno.
 
 ## When to Use Each Bridge in Deno
 
-| Scenario | Bridge | Notes |
-|----------|--------|-------|
-| Local Deno script | `NodeBridge` | Needs `--allow-run` |
-| Deno Deploy | `PyodideBridge` | WebAssembly, no subprocess |
-| Deno Deploy + heavy Python libs | `HttpBridge` | Python runs on a separate server |
+| Scenario                        | Bridge          | Notes                            |
+| ------------------------------- | --------------- | -------------------------------- |
+| Local Deno script               | `NodeBridge`    | Needs `--allow-run`              |
+| Deno Deploy                     | `PyodideBridge` | WebAssembly, no subprocess       |
+| Deno Deploy + heavy Python libs | `HttpBridge`    | Python runs on a separate server |
 
 ## Environment Variables
 
-The same `TYWRAP_*` env vars work under Deno. See the [environment variables reference](https://bbopen.github.io/tywrap/reference/env-vars).
+The same `TYWRAP_*` env vars work under Deno. See the
+[environment variables reference](https://bbopen.github.io/tywrap/reference/env-vars).
 
 ## Troubleshooting
 
-**`PermissionDenied: Requires run access to "python3"`** — Add `--allow-run=python3` to your `deno run` command.
+**`PermissionDenied: Requires run access to "python3"`** — Add
+`--allow-run=python3` to your `deno run` command.
 
-**`NotSupported: Subprocess access is not allowed`** — You are running in Deno Deploy. Switch to [`PyodideBridge`](https://bbopen.github.io/tywrap/guide/runtimes/browser) or [`HttpBridge`](https://bbopen.github.io/tywrap/guide/runtimes/http).
+**`NotSupported: Subprocess access is not allowed`** — You are running in Deno
+Deploy. Switch to [`PyodideBridge`](https://bbopen.github.io/tywrap/guide/runtimes/browser) or
+[`HttpBridge`](https://bbopen.github.io/tywrap/guide/runtimes/http).
 
 See the [Node.js troubleshooting guide](https://bbopen.github.io/tywrap/guide/runtimes/node) for additional patterns.
 
@@ -2366,29 +2378,32 @@ today.
 
 These affect the Python bridge or decoded runtime behavior.
 
-| Variable                   | Scope         | Default | Purpose                                                                        |
-| -------------------------- | ------------- | ------- | ------------------------------------------------------------------------------ |
-| `TYWRAP_CODEC_FALLBACK`    | Python bridge | unset   | Set to `json` to allow JSON fallback when Arrow encoding is unavailable        |
-| `TYWRAP_CODEC_MAX_BYTES`   | Python bridge | unset   | Reject response payloads larger than this byte count (applied post-reassembly) |
-| `TYWRAP_REQUEST_MAX_BYTES` | Python bridge | unset   | Reject request payloads larger than this byte count (applied post-reassembly)  |
-| `TYWRAP_TORCH_ALLOW_COPY`  | Python bridge | off     | Allow GPU-to-CPU or contiguous-copy conversion when serializing `torch.Tensor` |
+| Variable                     | Scope         | Default | Purpose                                                                                                                                                     |
+| ---------------------------- | ------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TYWRAP_CODEC_FALLBACK`      | Python bridge | unset   | Set to `json` to allow JSON fallback when Arrow encoding is unavailable                                                                                     |
+| `TYWRAP_CODEC_MAX_BYTES`     | Python bridge | unset   | Reject response payloads larger than this byte count (applied post-reassembly)                                                                              |
+| `TYWRAP_REQUEST_MAX_BYTES`   | Python bridge | unset   | Reject request payloads larger than this byte count (applied post-reassembly)                                                                               |
+| `TYWRAP_TORCH_ALLOW_COPY`    | Python bridge | off     | Allow GPU-to-CPU or contiguous-copy conversion when serializing `torch.Tensor`                                                                              |
+| `TYWRAP_ALLOWED_MODULES`     | Python bridge | unset   | Comma- and/or whitespace-separated import allowlist; blank is unset, while a non-empty value permits only named modules plus bridge-required stdlib modules |
+| `TYWRAP_ALLOW_PRIVATE_ATTRS` | Python bridge | off     | Set to `1`, `true`, or `yes` to allow underscore-prefixed attribute access; otherwise it is blocked                                                         |
 
 ## Chunked transport (`tywrap-frame/1`)
 
 These negotiate the large-payload chunked transport. They are set **by the Node
 subprocess transport on the Python bridge it spawns** when `enableChunking` is
-requested — you do not normally set them by hand. Chunking is **subprocess-only**
-(it is the only backend with a real frame ceiling, the JSONL line-length limit);
-HTTP and Pyodide are single-frame and ignore these. If the bridge does not see all
-three agree, it stays single-frame and an oversize payload fails loud — there is
-no silent single-frame fallback. See [Transport framing](https://bbopen.github.io/tywrap/transport-framing.md)
-and the [capability matrix](https://bbopen.github.io/tywrap/transport-capabilities.md).
+requested — you do not normally set them by hand. Chunking is
+**subprocess-only** (it is the only backend with a real frame ceiling, the JSONL
+line-length limit); HTTP and Pyodide are single-frame and ignore these. If the
+bridge does not see all three agree, it stays single-frame and an oversize
+payload fails loud — there is no silent single-frame fallback. See
+[Transport framing](https://bbopen.github.io/tywrap/transport-framing.md) and the
+[capability matrix](https://bbopen.github.io/tywrap/transport-capabilities.md).
 
-| Variable                           | Scope         | Default | Purpose                                                                                              |
-| ---------------------------------- | ------------- | ------- | ---------------------------------------------------------------------------------------------------- |
-| `TYWRAP_TRANSPORT_CHUNKING`        | Python bridge | unset   | Set to `1`/`true`/`yes` to enable `tywrap-frame/1` chunked framing on the bridge                     |
-| `TYWRAP_TRANSPORT_FRAME_PROTOCOL`  | Python bridge | unset   | The framing protocol the JS side advertises; must equal `tywrap-frame/1` for chunking to enable      |
-| `TYWRAP_TRANSPORT_MAX_FRAME_BYTES` | Python bridge | unset   | Per-frame UTF-8 byte ceiling for each frame's data slice (the JS side's JSONL `maxLineLength`)        |
+| Variable                           | Scope         | Default | Purpose                                                                                         |
+| ---------------------------------- | ------------- | ------- | ----------------------------------------------------------------------------------------------- |
+| `TYWRAP_TRANSPORT_CHUNKING`        | Python bridge | unset   | Set to `1`/`true`/`yes` to enable `tywrap-frame/1` chunked framing on the bridge                |
+| `TYWRAP_TRANSPORT_FRAME_PROTOCOL`  | Python bridge | unset   | The framing protocol the JS side advertises; must equal `tywrap-frame/1` for chunking to enable |
+| `TYWRAP_TRANSPORT_MAX_FRAME_BYTES` | Python bridge | unset   | Per-frame UTF-8 byte ceiling for each frame's data slice (the JS side's JSONL `maxLineLength`)  |
 
 ## Logging
 
@@ -3206,21 +3221,21 @@ const result = await bridge.call('math', 'sqrt', [16]);
 const info = await bridge.getBridgeInfo({ refresh: true });
 ```
 
-| Option                    | Default         | Notes                                           |
-| ------------------------- | --------------- | ----------------------------------------------- |
-| `pythonPath`              | auto-detect     | Python executable                               |
-| `scriptPath`              | built-in bridge | Custom `python_bridge.py`                       |
-| `virtualEnv`              | —               | Virtual environment root                        |
-| `cwd`                     | `process.cwd()` | Subprocess working directory                    |
-| `timeoutMs`               | `30000`         | Per-call timeout                                |
-| `queueTimeoutMs`          | `30000`         | Wait time when the worker pool is saturated     |
-| `minProcesses`            | `1`             | Minimum worker count                            |
-| `maxProcesses`            | `1`             | Maximum worker count                            |
-| `maxConcurrentPerProcess` | `1`             | Concurrent requests per serial Python worker    |
-| `inheritProcessEnv`       | `false`         | Pass full parent env through                    |
-| `env`                     | `{}`            | Extra subprocess env vars                       |
-| `codec`                   | —               | `CodecOptions` for validation and byte handling |
-| `warmupCommands`          | `[]`            | Per-worker startup calls                        |
+| Option                    | Default         | Notes                                                                                   |
+| ------------------------- | --------------- | --------------------------------------------------------------------------------------- |
+| `pythonPath`              | auto-detect     | Python executable                                                                       |
+| `scriptPath`              | built-in bridge | Custom `python_bridge.py`                                                               |
+| `virtualEnv`              | —               | Virtual environment root                                                                |
+| `cwd`                     | `process.cwd()` | Subprocess working directory                                                            |
+| `timeoutMs`               | `30000`         | Per-call timeout                                                                        |
+| `queueTimeoutMs`          | `30000`         | Wait time when the worker pool is saturated                                             |
+| `minProcesses`            | `1`             | Minimum worker count                                                                    |
+| `maxProcesses`            | `1`             | Maximum worker count                                                                    |
+| `maxConcurrentPerProcess` | `1`             | Concurrent requests per serial Python worker; use more worker processes for concurrency |
+| `inheritProcessEnv`       | `false`         | Pass full parent env through                                                            |
+| `env`                     | `{}`            | Extra subprocess env vars                                                               |
+| `codec`                   | —               | `CodecOptions` for validation and byte handling                                         |
+| `warmupCommands`          | `[]`            | Per-worker startup calls                                                                |
 
 Deprecated compatibility fields still exist on the interface: `maxIdleTime`,
 `maxRequestsPerProcess`, `enableJsonFallback`, and `maxLineLength`.

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,9 +1,10 @@
 # tywrap
 
-> TypeScript wrapper generator for Python libraries. Auto-generates type-safe
-> TypeScript bindings from Python source via AST analysis, then calls them at
-> runtime over a subprocess bridge (Node.js, Bun, Deno), in-browser WebAssembly
-> (Pyodide), or HTTP. Apache Arrow is the default binary transport for
+> TypeScript binding generator for Python libraries. It produces precise
+> TypeScript types for fully annotated, in-module, serializable Python returns
+> and falls back where a type cannot be resolved, then calls them at runtime
+> over a subprocess bridge (Node.js, Bun, experimental/untested Deno),
+> in-browser WebAssembly (Pyodide), or HTTP. Apache Arrow is the default binary transport for
 > numpy/pandas data (JSON fallback); the Node bridge chunks results larger than
 > a single JSONL line. Experimental (pre-v1.0.0) — APIs may change.
 
@@ -14,7 +15,7 @@
 - [Runtime Comparison](https://bbopen.github.io/tywrap/guide/runtimes/comparison): Which bridge to use and when
 - [Node.js Runtime](https://bbopen.github.io/tywrap/guide/runtimes/node): NodeBridge setup, virtual envs, pooling, large-payload chunking
 - [Bun Runtime](https://bbopen.github.io/tywrap/guide/runtimes/bun): NodeBridge on Bun, bunfig.toml
-- [Deno Runtime](https://bbopen.github.io/tywrap/guide/runtimes/deno): npm: prefix, --allow-run, Deno Deploy limitation
+- [Deno Runtime](https://bbopen.github.io/tywrap/guide/runtimes/deno): Experimental, untested-in-CI subprocess support; npm: prefix, --allow-run, Deno Deploy limitation
 - [Browser Runtime (Pyodide)](https://bbopen.github.io/tywrap/guide/runtimes/browser): WebAssembly Python, no subprocess needed
 - [HTTP Bridge](https://bbopen.github.io/tywrap/guide/runtimes/http): Remote Python server, stateless HTTP POST
 - [Development Hot Reload](https://bbopen.github.io/tywrap/guide/dev-reload): tywrap/dev watch sessions, bridge swap, reload contract

--- a/docs/reference/api/index.md
+++ b/docs/reference/api/index.md
@@ -130,21 +130,21 @@ const result = await bridge.call('math', 'sqrt', [16]);
 const info = await bridge.getBridgeInfo({ refresh: true });
 ```
 
-| Option                    | Default         | Notes                                           |
-| ------------------------- | --------------- | ----------------------------------------------- |
-| `pythonPath`              | auto-detect     | Python executable                               |
-| `scriptPath`              | built-in bridge | Custom `python_bridge.py`                       |
-| `virtualEnv`              | —               | Virtual environment root                        |
-| `cwd`                     | `process.cwd()` | Subprocess working directory                    |
-| `timeoutMs`               | `30000`         | Per-call timeout                                |
-| `queueTimeoutMs`          | `30000`         | Wait time when the worker pool is saturated     |
-| `minProcesses`            | `1`             | Minimum worker count                            |
-| `maxProcesses`            | `1`             | Maximum worker count                            |
-| `maxConcurrentPerProcess` | `1`             | Concurrent requests per serial Python worker    |
-| `inheritProcessEnv`       | `false`         | Pass full parent env through                    |
-| `env`                     | `{}`            | Extra subprocess env vars                       |
-| `codec`                   | —               | `CodecOptions` for validation and byte handling |
-| `warmupCommands`          | `[]`            | Per-worker startup calls                        |
+| Option                    | Default         | Notes                                                                                   |
+| ------------------------- | --------------- | --------------------------------------------------------------------------------------- |
+| `pythonPath`              | auto-detect     | Python executable                                                                       |
+| `scriptPath`              | built-in bridge | Custom `python_bridge.py`                                                               |
+| `virtualEnv`              | —               | Virtual environment root                                                                |
+| `cwd`                     | `process.cwd()` | Subprocess working directory                                                            |
+| `timeoutMs`               | `30000`         | Per-call timeout                                                                        |
+| `queueTimeoutMs`          | `30000`         | Wait time when the worker pool is saturated                                             |
+| `minProcesses`            | `1`             | Minimum worker count                                                                    |
+| `maxProcesses`            | `1`             | Maximum worker count                                                                    |
+| `maxConcurrentPerProcess` | `1`             | Concurrent requests per serial Python worker; use more worker processes for concurrency |
+| `inheritProcessEnv`       | `false`         | Pass full parent env through                                                            |
+| `env`                     | `{}`            | Extra subprocess env vars                                                               |
+| `codec`                   | —               | `CodecOptions` for validation and byte handling                                         |
+| `warmupCommands`          | `[]`            | Per-worker startup calls                                                                |
 
 Deprecated compatibility fields still exist on the interface: `maxIdleTime`,
 `maxRequestsPerProcess`, `enableJsonFallback`, and `maxLineLength`.

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -7,29 +7,32 @@ today.
 
 These affect the Python bridge or decoded runtime behavior.
 
-| Variable                   | Scope         | Default | Purpose                                                                        |
-| -------------------------- | ------------- | ------- | ------------------------------------------------------------------------------ |
-| `TYWRAP_CODEC_FALLBACK`    | Python bridge | unset   | Set to `json` to allow JSON fallback when Arrow encoding is unavailable        |
-| `TYWRAP_CODEC_MAX_BYTES`   | Python bridge | unset   | Reject response payloads larger than this byte count (applied post-reassembly) |
-| `TYWRAP_REQUEST_MAX_BYTES` | Python bridge | unset   | Reject request payloads larger than this byte count (applied post-reassembly)  |
-| `TYWRAP_TORCH_ALLOW_COPY`  | Python bridge | off     | Allow GPU-to-CPU or contiguous-copy conversion when serializing `torch.Tensor` |
+| Variable                     | Scope         | Default | Purpose                                                                                                                                                     |
+| ---------------------------- | ------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TYWRAP_CODEC_FALLBACK`      | Python bridge | unset   | Set to `json` to allow JSON fallback when Arrow encoding is unavailable                                                                                     |
+| `TYWRAP_CODEC_MAX_BYTES`     | Python bridge | unset   | Reject response payloads larger than this byte count (applied post-reassembly)                                                                              |
+| `TYWRAP_REQUEST_MAX_BYTES`   | Python bridge | unset   | Reject request payloads larger than this byte count (applied post-reassembly)                                                                               |
+| `TYWRAP_TORCH_ALLOW_COPY`    | Python bridge | off     | Allow GPU-to-CPU or contiguous-copy conversion when serializing `torch.Tensor`                                                                              |
+| `TYWRAP_ALLOWED_MODULES`     | Python bridge | unset   | Comma- and/or whitespace-separated import allowlist; blank is unset, while a non-empty value permits only named modules plus bridge-required stdlib modules |
+| `TYWRAP_ALLOW_PRIVATE_ATTRS` | Python bridge | off     | Set to `1`, `true`, or `yes` to allow underscore-prefixed attribute access; otherwise it is blocked                                                         |
 
 ## Chunked transport (`tywrap-frame/1`)
 
 These negotiate the large-payload chunked transport. They are set **by the Node
 subprocess transport on the Python bridge it spawns** when `enableChunking` is
-requested — you do not normally set them by hand. Chunking is **subprocess-only**
-(it is the only backend with a real frame ceiling, the JSONL line-length limit);
-HTTP and Pyodide are single-frame and ignore these. If the bridge does not see all
-three agree, it stays single-frame and an oversize payload fails loud — there is
-no silent single-frame fallback. See [Transport framing](../transport-framing.md)
-and the [capability matrix](../transport-capabilities.md).
+requested — you do not normally set them by hand. Chunking is
+**subprocess-only** (it is the only backend with a real frame ceiling, the JSONL
+line-length limit); HTTP and Pyodide are single-frame and ignore these. If the
+bridge does not see all three agree, it stays single-frame and an oversize
+payload fails loud — there is no silent single-frame fallback. See
+[Transport framing](../transport-framing.md) and the
+[capability matrix](../transport-capabilities.md).
 
-| Variable                           | Scope         | Default | Purpose                                                                                              |
-| ---------------------------------- | ------------- | ------- | ---------------------------------------------------------------------------------------------------- |
-| `TYWRAP_TRANSPORT_CHUNKING`        | Python bridge | unset   | Set to `1`/`true`/`yes` to enable `tywrap-frame/1` chunked framing on the bridge                     |
-| `TYWRAP_TRANSPORT_FRAME_PROTOCOL`  | Python bridge | unset   | The framing protocol the JS side advertises; must equal `tywrap-frame/1` for chunking to enable      |
-| `TYWRAP_TRANSPORT_MAX_FRAME_BYTES` | Python bridge | unset   | Per-frame UTF-8 byte ceiling for each frame's data slice (the JS side's JSONL `maxLineLength`)        |
+| Variable                           | Scope         | Default | Purpose                                                                                         |
+| ---------------------------------- | ------------- | ------- | ----------------------------------------------------------------------------------------------- |
+| `TYWRAP_TRANSPORT_CHUNKING`        | Python bridge | unset   | Set to `1`/`true`/`yes` to enable `tywrap-frame/1` chunked framing on the bridge                |
+| `TYWRAP_TRANSPORT_FRAME_PROTOCOL`  | Python bridge | unset   | The framing protocol the JS side advertises; must equal `tywrap-frame/1` for chunking to enable |
+| `TYWRAP_TRANSPORT_MAX_FRAME_BYTES` | Python bridge | unset   | Per-frame UTF-8 byte ceiling for each frame's data slice (the JS side's JSONL `maxLineLength`)  |
 
 ## Logging
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tywrap",
   "version": "0.8.0",
-  "description": "Generate type-safe TypeScript wrappers for any Python library \u2014 Node.js, Deno, Bun, and browsers via Pyodide.",
+  "description": "Generate TypeScript bindings for Python libraries with precise types where tywrap can resolve them — Node.js, experimental Deno, Bun, and browsers via Pyodide.",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -88,7 +88,7 @@
     "typescript",
     "python",
     "bridge",
-    "type-safety",
+    "typed-bindings",
     "interop",
     "pyodide",
     "ast",


### PR DESCRIPTION
## Summary

- Describe tywrap's precise type coverage for fully annotated, in-module,
  serializable Python returns and its fallback behavior.
- Correct runtime and metadata wording, including experimental, untested Deno
  subprocess support.
- Document bridge allowlist/private-attribute environment variables and align
  stale pool and result-cache documentation with current behavior.

Closes #261
