### PR TITLE
docs(bridge): correct python_bridge docstring — no HTTP transport ships

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,8 +15,8 @@ Two environment-variable controls bound that surface:
 - Underscore-prefixed attributes are blocked by default. Set
   `TYWRAP_ALLOW_PRIVATE_ATTRS=1` only to opt out for trusted code.
 
-No HTTP server ships with tywrap. `HttpBridge` is a client for a server that you
-run and secure.
+No HTTP server or server-side HTTP transport ships with tywrap. `HttpBridge`
+only connects to a server that you run and secure.
 
 ## Network exposure
 

--- a/docs/guide/runtimes/http.md
+++ b/docs/guide/runtimes/http.md
@@ -1,6 +1,8 @@
 # HTTP Bridge Guide
 
-`HttpBridge` connects to a Python server over HTTP. Use it when Python must run separately — including Deno Deploy, serverless environments, or distributed architectures.
+`HttpBridge` connects to a Python server over HTTP. Use it when Python must run
+separately — including Deno Deploy, serverless environments, or distributed
+architectures.
 
 ## When to Use HttpBridge
 
@@ -21,29 +23,34 @@ pip install tywrap-ir
 import { HttpBridge } from 'tywrap/http';
 import { setRuntimeBridge } from 'tywrap/runtime';
 
-setRuntimeBridge(new HttpBridge({
-  baseURL: 'http://localhost:8080',
-  timeoutMs: 30000,
-  headers: {
-    'Authorization': 'Bearer your-token',
-  },
-}));
+setRuntimeBridge(
+  new HttpBridge({
+    baseURL: 'http://localhost:8080',
+    timeoutMs: 30000,
+    headers: {
+      Authorization: 'Bearer your-token',
+    },
+  })
+);
 ```
 
 ## Options
 
-| Option | Required | Default | Description |
-|--------|----------|---------|-------------|
-| `baseURL` | Yes | — | Base URL of the Python bridge server |
-| `headers` | No | `{}` | Additional HTTP headers (auth, CORS, etc.) |
-| `timeoutMs` | No | `30000` | Request timeout in milliseconds |
-| `codec` | No | Arrow | Codec options |
+| Option      | Required | Default | Description                                |
+| ----------- | -------- | ------- | ------------------------------------------ |
+| `baseURL`   | Yes      | —       | Base URL of the Python bridge server       |
+| `headers`   | No       | `{}`    | Additional HTTP headers (auth, CORS, etc.) |
+| `timeoutMs` | No       | `30000` | Request timeout in milliseconds            |
+| `codec`     | No       | Arrow   | Codec options                              |
 
 ## Running the Python Server
 
-`HttpBridge` expects a server that accepts POST requests with JSON/Arrow payloads. You must implement or deploy a compatible server endpoint. The protocol is stateless — each call is an independent POST request.
+`HttpBridge` expects a server that accepts POST requests with JSON/Arrow
+payloads. You must implement or deploy a compatible server endpoint. The
+protocol is stateless — each call is an independent POST request.
 
-> **Note:** A built-in server command is not yet available. See the [API reference](/reference/api/) for the expected request/response format.
+> **Note:** tywrap does not ship an HTTP server. See the
+> [API reference](/reference/api/) for the expected request/response format.
 
 ## Apache Arrow
 
@@ -58,10 +65,10 @@ registerArrowDecoder(bytes => tableFromIPC(bytes));
 
 ## Environment Variables
 
-| Var | Purpose |
-|-----|---------|
+| Var                          | Purpose                      |
+| ---------------------------- | ---------------------------- |
 | `TYWRAP_CODEC_FALLBACK=json` | Disable Arrow, use JSON only |
-| `TYWRAP_CODEC_MAX_BYTES` | Cap max response size |
+| `TYWRAP_CODEC_MAX_BYTES`     | Cap max response size        |
 
 See the [environment variables reference](/reference/env-vars).
 

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -2031,7 +2031,9 @@ Run `tywrap generate` during your build and load Pyodide at runtime (CDN or self
 <!-- Source: docs/guide/runtimes/http.md -->
 # HTTP Bridge Guide
 
-`HttpBridge` connects to a Python server over HTTP. Use it when Python must run separately — including Deno Deploy, serverless environments, or distributed architectures.
+`HttpBridge` connects to a Python server over HTTP. Use it when Python must run
+separately — including Deno Deploy, serverless environments, or distributed
+architectures.
 
 ## When to Use HttpBridge
 
@@ -2052,29 +2054,34 @@ pip install tywrap-ir
 import { HttpBridge } from 'tywrap/http';
 import { setRuntimeBridge } from 'tywrap/runtime';
 
-setRuntimeBridge(new HttpBridge({
-  baseURL: 'http://localhost:8080',
-  timeoutMs: 30000,
-  headers: {
-    'Authorization': 'Bearer your-token',
-  },
-}));
+setRuntimeBridge(
+  new HttpBridge({
+    baseURL: 'http://localhost:8080',
+    timeoutMs: 30000,
+    headers: {
+      Authorization: 'Bearer your-token',
+    },
+  })
+);
 ```
 
 ## Options
 
-| Option | Required | Default | Description |
-|--------|----------|---------|-------------|
-| `baseURL` | Yes | — | Base URL of the Python bridge server |
-| `headers` | No | `{}` | Additional HTTP headers (auth, CORS, etc.) |
-| `timeoutMs` | No | `30000` | Request timeout in milliseconds |
-| `codec` | No | Arrow | Codec options |
+| Option      | Required | Default | Description                                |
+| ----------- | -------- | ------- | ------------------------------------------ |
+| `baseURL`   | Yes      | —       | Base URL of the Python bridge server       |
+| `headers`   | No       | `{}`    | Additional HTTP headers (auth, CORS, etc.) |
+| `timeoutMs` | No       | `30000` | Request timeout in milliseconds            |
+| `codec`     | No       | Arrow   | Codec options                              |
 
 ## Running the Python Server
 
-`HttpBridge` expects a server that accepts POST requests with JSON/Arrow payloads. You must implement or deploy a compatible server endpoint. The protocol is stateless — each call is an independent POST request.
+`HttpBridge` expects a server that accepts POST requests with JSON/Arrow
+payloads. You must implement or deploy a compatible server endpoint. The
+protocol is stateless — each call is an independent POST request.
 
-> **Note:** A built-in server command is not yet available. See the [API reference](https://bbopen.github.io/tywrap/reference/api/) for the expected request/response format.
+> **Note:** tywrap does not ship an HTTP server. See the
+> [API reference](https://bbopen.github.io/tywrap/reference/api/) for the expected request/response format.
 
 ## Apache Arrow
 
@@ -2089,10 +2096,10 @@ registerArrowDecoder(bytes => tableFromIPC(bytes));
 
 ## Environment Variables
 
-| Var | Purpose |
-|-----|---------|
+| Var                          | Purpose                      |
+| ---------------------------- | ---------------------------- |
 | `TYWRAP_CODEC_FALLBACK=json` | Disable Arrow, use JSON only |
-| `TYWRAP_CODEC_MAX_BYTES` | Cap max response size |
+| `TYWRAP_CODEC_MAX_BYTES`     | Cap max response size        |
 
 See the [environment variables reference](https://bbopen.github.io/tywrap/reference/env-vars).
 
@@ -2378,14 +2385,14 @@ today.
 
 These affect the Python bridge or decoded runtime behavior.
 
-| Variable                     | Scope         | Default | Purpose                                                                                                                                                     |
-| ---------------------------- | ------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `TYWRAP_CODEC_FALLBACK`      | Python bridge | unset   | Set to `json` to allow JSON fallback when Arrow encoding is unavailable                                                                                     |
-| `TYWRAP_CODEC_MAX_BYTES`     | Python bridge | unset   | Reject response payloads larger than this byte count (applied post-reassembly)                                                                              |
-| `TYWRAP_REQUEST_MAX_BYTES`   | Python bridge | unset   | Reject request payloads larger than this byte count (applied post-reassembly)                                                                               |
-| `TYWRAP_TORCH_ALLOW_COPY`    | Python bridge | off     | Allow GPU-to-CPU or contiguous-copy conversion when serializing `torch.Tensor`                                                                              |
-| `TYWRAP_ALLOWED_MODULES`     | Python bridge | unset   | Comma- and/or whitespace-separated import allowlist; blank is unset, while a non-empty value permits only named modules plus bridge-required stdlib modules |
-| `TYWRAP_ALLOW_PRIVATE_ATTRS` | Python bridge | off     | Set to `1`, `true`, or `yes` to allow underscore-prefixed attribute access; otherwise it is blocked                                                         |
+| Variable                     | Scope         | Default | Purpose                                                                                                                                                                                                                                 |
+| ---------------------------- | ------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TYWRAP_CODEC_FALLBACK`      | Python bridge | unset   | Set to `json` to allow JSON fallback when Arrow encoding is unavailable                                                                                                                                                                 |
+| `TYWRAP_CODEC_MAX_BYTES`     | Python bridge | unset   | Reject response payloads larger than this byte count (applied post-reassembly)                                                                                                                                                          |
+| `TYWRAP_REQUEST_MAX_BYTES`   | Python bridge | unset   | Reject request payloads larger than this byte count (applied post-reassembly)                                                                                                                                                           |
+| `TYWRAP_TORCH_ALLOW_COPY`    | Python bridge | off     | Allow GPU-to-CPU or contiguous-copy conversion when serializing `torch.Tensor`                                                                                                                                                          |
+| `TYWRAP_ALLOWED_MODULES`     | Python bridge | unset   | Comma- and/or whitespace-separated import allowlist; blank is unset, while a non-empty value permits only named modules plus bridge-required stdlib modules. See [SECURITY.md](https://github.com/bbopen/tywrap/blob/main/SECURITY.md). |
+| `TYWRAP_ALLOW_PRIVATE_ATTRS` | Python bridge | off     | Set to `1`, `true`, or `yes` to allow underscore-prefixed attribute access; otherwise it is blocked                                                                                                                                     |
 
 ## Chunked transport (`tywrap-frame/1`)
 

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -7,14 +7,14 @@ today.
 
 These affect the Python bridge or decoded runtime behavior.
 
-| Variable                     | Scope         | Default | Purpose                                                                                                                                                     |
-| ---------------------------- | ------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `TYWRAP_CODEC_FALLBACK`      | Python bridge | unset   | Set to `json` to allow JSON fallback when Arrow encoding is unavailable                                                                                     |
-| `TYWRAP_CODEC_MAX_BYTES`     | Python bridge | unset   | Reject response payloads larger than this byte count (applied post-reassembly)                                                                              |
-| `TYWRAP_REQUEST_MAX_BYTES`   | Python bridge | unset   | Reject request payloads larger than this byte count (applied post-reassembly)                                                                               |
-| `TYWRAP_TORCH_ALLOW_COPY`    | Python bridge | off     | Allow GPU-to-CPU or contiguous-copy conversion when serializing `torch.Tensor`                                                                              |
-| `TYWRAP_ALLOWED_MODULES`     | Python bridge | unset   | Comma- and/or whitespace-separated import allowlist; blank is unset, while a non-empty value permits only named modules plus bridge-required stdlib modules |
-| `TYWRAP_ALLOW_PRIVATE_ATTRS` | Python bridge | off     | Set to `1`, `true`, or `yes` to allow underscore-prefixed attribute access; otherwise it is blocked                                                         |
+| Variable                     | Scope         | Default | Purpose                                                                                                                                                                                                                                 |
+| ---------------------------- | ------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TYWRAP_CODEC_FALLBACK`      | Python bridge | unset   | Set to `json` to allow JSON fallback when Arrow encoding is unavailable                                                                                                                                                                 |
+| `TYWRAP_CODEC_MAX_BYTES`     | Python bridge | unset   | Reject response payloads larger than this byte count (applied post-reassembly)                                                                                                                                                          |
+| `TYWRAP_REQUEST_MAX_BYTES`   | Python bridge | unset   | Reject request payloads larger than this byte count (applied post-reassembly)                                                                                                                                                           |
+| `TYWRAP_TORCH_ALLOW_COPY`    | Python bridge | off     | Allow GPU-to-CPU or contiguous-copy conversion when serializing `torch.Tensor`                                                                                                                                                          |
+| `TYWRAP_ALLOWED_MODULES`     | Python bridge | unset   | Comma- and/or whitespace-separated import allowlist; blank is unset, while a non-empty value permits only named modules plus bridge-required stdlib modules. See [SECURITY.md](https://github.com/bbopen/tywrap/blob/main/SECURITY.md). |
+| `TYWRAP_ALLOW_PRIVATE_ATTRS` | Python bridge | off     | Set to `1`, `true`, or `yes` to allow underscore-prefixed attribute access; otherwise it is blocked                                                                                                                                     |
 
 ## Chunked transport (`tywrap-frame/1`)
 

--- a/runtime/python_bridge.py
+++ b/runtime/python_bridge.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python3
 """
-Reference tywrap Python bridge server (subprocess + HTTP transports).
+Reference tywrap Python subprocess bridge.
+
+This module implements only the stdin/stdout subprocess loop for the Node/Bun/
+Deno transport. `HttpBridge` connects to an HTTP server provided by the
+operator; tywrap does not ship that server or an HTTP transport in this module.
+The operator is responsible for securing any network exposure.
 
 This module owns the I/O concerns and process identity for the Node/Bun/Deno
-subprocess transport and the HTTP transport:
+subprocess transport:
   - the stdin/stdout JSONL request/response loop (main())
   - env-var size guards (TYWRAP_CODEC_MAX_BYTES / TYWRAP_REQUEST_MAX_BYTES)
   - TYWRAP_CODEC_FALLBACK=json marker mode and TYWRAP_TORCH_ALLOW_COPY


### PR DESCRIPTION
## Summary

- Correct the Python bridge docstring: only the stdin/stdout subprocess loop
  ships; `HttpBridge` connects to an operator-provided server.
- Reinforce the same server-author security contract in the policy, environment
  reference, and HTTP runtime guide.

Closes #263

## Deferred

The optional allowlist/auth parameter on core dispatch is intentionally deferred;
this documentation-only change adds no dispatch code.
