### PR TITLE
docs: add SECURITY.md documenting the bridge trust model

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,8 +229,8 @@ registerArrowDecoder(bytes => tableFromIPC(bytes));
 
 ## Security
 
-See [SECURITY.md](./SECURITY.md) for the bridge trust model and vulnerability
-reporting.
+Read the [Security policy](./SECURITY.md) for the bridge trust model and
+vulnerability reporting.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Bridge trust model
+
+The tywrap Python bridge imports modules, reads attributes from them, and calls
+the modules and attributes named by its caller. It does **not** sandbox the
+Python code it runs. Treat every module and attribute exposed through the bridge
+as trusted code.
+
+Two environment-variable controls bound that surface:
+
+- `TYWRAP_ALLOWED_MODULES` is an import allowlist. Set it to a non-empty, comma-
+  and/or whitespace-separated list of allowed module names to limit imports to
+  those modules (plus standard-library modules the bridge needs).
+- Underscore-prefixed attributes are blocked by default. Set
+  `TYWRAP_ALLOW_PRIVATE_ATTRS=1` only to opt out for trusted code.
+
+No HTTP server ships with tywrap. `HttpBridge` is a client for a server that you
+run and secure.
+
+## Network exposure
+
+If you expose a bridge over a network, configure a non-empty
+`TYWRAP_ALLOWED_MODULES` allowlist and provide your own authentication. The
+local subprocess bridge's default allow-all import behavior is intended only for
+trusted, same-user use.
+
+## Supported versions
+
+| Version            | Security fixes |
+| ------------------ | -------------- |
+| Latest 0.x minor   | Yes            |
+| Earlier 0.x minors | No             |
+
+## Reporting a vulnerability
+
+Please use
+[GitHub private vulnerability reporting](https://github.com/bbopen/tywrap/security/advisories/new):
+open the repository's **Security** tab and choose **Report a vulnerability**.

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -33,3 +33,4 @@
 - [Releases](https://github.com/bbopen/tywrap/releases): Version history and breaking changes
 - [Contributing](https://github.com/bbopen/tywrap/blob/main/CONTRIBUTING.md): Development setup, PR guidelines
 - [AGENTS.md](https://github.com/bbopen/tywrap/blob/main/AGENTS.md): AI coding agent build/test instructions
+- [Security Policy](https://github.com/bbopen/tywrap/blob/main/SECURITY.md): Bridge trust model and vulnerability reporting

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "dist",
     "runtime",
     "src",
-    "README.md"
+    "README.md",
+    "SECURITY.md"
   ],
   "scripts": {
     "build": "npm run build:version && npm run build:pyodide-bootstrap && tsc && npm run build:tools",


### PR DESCRIPTION
## Summary

- Add a packaged `SECURITY.md` that documents the bridge trust model.
- Explain allowlisting, private-attribute protection, network-exposure
  requirements, supported versions, and private vulnerability reporting.
- Link the README and agent index to the new security policy.

Closes #262

(Replaces #291, which GitHub auto-closed when its stacked base branch was deleted on #290's merge.)