### PR TITLE
chore(utils): trim runtime.ts to verified-live helpers

### DIFF
--- a/src/utils/runtime.ts
+++ b/src/utils/runtime.ts
@@ -23,13 +23,16 @@ interface RuntimeCapabilities {
 
 // Cache for runtime detection to avoid repeated environment checks
 let runtimeCache: RuntimeInfo | null = null;
+let runtimeCacheSignature: string | undefined;
 
-/**
- * Clear runtime cache (for testing purposes only)
- * @internal
- */
-export function clearRuntimeCache(): void {
-  runtimeCache = null;
+function currentRuntimeSignature(): string {
+  return [
+    typeof Deno !== 'undefined' && Deno !== null,
+    typeof Bun !== 'undefined' && Bun !== null,
+    typeof process !== 'undefined' && process.versions?.node,
+    typeof window !== 'undefined' ? window.isSecureContext : undefined,
+    typeof self !== 'undefined' ? self.isSecureContext : undefined,
+  ].join('|');
 }
 
 /**
@@ -37,7 +40,8 @@ export function clearRuntimeCache(): void {
  * Results are cached and frozen to prevent external mutation
  */
 export function detectRuntime(): RuntimeInfo {
-  if (runtimeCache) {
+  const signature = currentRuntimeSignature();
+  if (runtimeCache && runtimeCacheSignature === signature) {
     return runtimeCache;
   }
   // Deno detection (must come before Node.js check)
@@ -56,6 +60,7 @@ export function detectRuntime(): RuntimeInfo {
       capabilities: Object.freeze(capabilities),
     };
     runtimeCache = Object.freeze(result) as RuntimeInfo;
+    runtimeCacheSignature = signature;
     return runtimeCache;
   }
 
@@ -75,6 +80,7 @@ export function detectRuntime(): RuntimeInfo {
       capabilities: Object.freeze(capabilities),
     };
     runtimeCache = Object.freeze(result) as RuntimeInfo;
+    runtimeCacheSignature = signature;
     return runtimeCache;
   }
 
@@ -94,6 +100,7 @@ export function detectRuntime(): RuntimeInfo {
       capabilities: Object.freeze(capabilities),
     };
     runtimeCache = Object.freeze(result) as RuntimeInfo;
+    runtimeCacheSignature = signature;
     return runtimeCache;
   }
 
@@ -119,6 +126,7 @@ export function detectRuntime(): RuntimeInfo {
       capabilities: Object.freeze(capabilities),
     };
     runtimeCache = Object.freeze(result) as RuntimeInfo;
+    runtimeCacheSignature = signature;
     return runtimeCache;
   }
 
@@ -137,6 +145,7 @@ export function detectRuntime(): RuntimeInfo {
 
   // Cache and freeze the result to prevent external mutation
   runtimeCache = Object.freeze(result) as RuntimeInfo;
+  runtimeCacheSignature = signature;
   return runtimeCache;
 }
 

--- a/test/runtime_bun.test.ts
+++ b/test/runtime_bun.test.ts
@@ -5,14 +5,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { rm, mkdir } from 'node:fs/promises';
-import {
-  isBun,
-  detectRuntime,
-  processUtils,
-  fsUtils,
-  pathUtils,
-  clearRuntimeCache,
-} from '../src/utils/runtime.js';
+import { isBun, detectRuntime, processUtils, fsUtils, pathUtils } from '../src/utils/runtime.js';
 
 // Skip all tests if not running in Bun environment
 const describeBunOnly = isBun() ? describe : describe.skip;
@@ -28,14 +21,12 @@ describeBunOnly('Bun Runtime Support', () => {
 
   describe('Runtime Detection', () => {
     it('should detect Bun runtime correctly', () => {
-      clearRuntimeCache();
       const runtime = detectRuntime();
       expect(runtime.name).toBe('bun');
       expect(runtime.version).toBe(Bun.version);
     });
 
     it('should report correct capabilities for Bun', () => {
-      clearRuntimeCache();
       const runtime = detectRuntime();
       expect(runtime.capabilities).toEqual({
         filesystem: true,
@@ -55,11 +46,9 @@ describeBunOnly('Bun Runtime Support', () => {
       const originalBun = (globalThis as any).Bun;
       try {
         delete (globalThis as any).Bun;
-        clearRuntimeCache();
         expect(isBun()).toBe(false);
       } finally {
         (globalThis as any).Bun = originalBun;
-        clearRuntimeCache();
       }
     });
   });

--- a/test/runtime_detection.test.ts
+++ b/test/runtime_detection.test.ts
@@ -16,7 +16,6 @@ import {
   fsUtils,
   processUtils,
   hashUtils,
-  clearRuntimeCache,
   type Runtime,
 } from '../src/utils/runtime.js';
 
@@ -36,9 +35,6 @@ describeRuntimeDetection('Runtime Detection', () => {
   } = {};
 
   beforeEach(() => {
-    // Clear runtime cache before each test
-    clearRuntimeCache();
-
     // Store original globals
     originalGlobals = {
       Deno: (globalThis as any).Deno,
@@ -61,9 +57,6 @@ describeRuntimeDetection('Runtime Detection', () => {
         delete (globalThis as any)[key];
       }
     });
-
-    // Clear runtime cache after restoring globals
-    clearRuntimeCache();
   });
 
   describe('Basic Runtime Detection', () => {

--- a/test/runtime_utils.test.ts
+++ b/test/runtime_utils.test.ts
@@ -2,7 +2,7 @@
  * Runtime detection and path utilities tests
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   detectRuntime,
   pathUtils,
@@ -10,20 +10,9 @@ import {
   isDeno,
   isBun,
   isBrowser,
-  clearRuntimeCache,
 } from '../src/utils/runtime.js';
 
 describe('Runtime Detection', () => {
-  beforeEach(() => {
-    // Clear runtime cache before each test
-    clearRuntimeCache();
-  });
-
-  afterEach(() => {
-    // Clear runtime cache after each test
-    clearRuntimeCache();
-  });
-
   it('should cache runtime detection results', () => {
     const first = detectRuntime();
     const second = detectRuntime();
@@ -117,12 +106,7 @@ describe('Runtime Detection', () => {
 });
 
 describe('Path Utilities', () => {
-  beforeEach(() => {
-    clearRuntimeCache();
-  });
-
   afterEach(() => {
-    clearRuntimeCache();
     vi.unstubAllGlobals();
   });
 
@@ -198,7 +182,6 @@ describe('Path Utilities', () => {
       vi.stubGlobal('Bun', undefined);
       vi.stubGlobal('window', { isSecureContext: true });
       vi.stubGlobal('location', { href: 'https://example.com/app/' });
-      clearRuntimeCache();
     });
 
     it('should normalize paths in browser runtime', () => {


### PR DESCRIPTION
## Summary

- Remove the test-only `clearRuntimeCache` export from `src/utils/runtime.ts`.
- Preserve runtime detection caching while automatically invalidating its cache
  when the observable runtime globals change.
- Update runtime-detection tests to exercise the public detection surface.

## What broke and why it cannot now

`clearRuntimeCache` was a testing hook in production runtime utilities with no
production or generated-template caller. Cache invalidation is now tied to the runtime discriminants
that select Node, Deno, Bun, browser, or unknown, so tests and embedders do not
need a mutable reset API to observe a changed environment.

## BREAKING CHANGE

`clearRuntimeCache` is no longer exported. It was documented as test-only and
had no production caller in `src/`; consumers should call `detectRuntime()`
directly.
