### PR TITLE
feat(core)!: pinned IR contract artifact with cross-language version check

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -118,6 +118,7 @@ function detectLegacyFields(config: TywrapConfig): void {
 const ALLOWED_TOP_LEVEL = new Set([
   'pythonModules',
   'pythonImportPath',
+  'contractInput',
   'output',
   'runtime',
   'performance',
@@ -275,6 +276,15 @@ function validateConfig(config: ResolvedTywrapConfig): void {
 
   if (config.pythonImportPath !== undefined && !isStringArray(config.pythonImportPath)) {
     throw new Error('pythonImportPath must be an array of strings');
+  }
+
+  if (
+    config.contractInput !== undefined &&
+    typeof config.contractInput !== 'string' &&
+    (!isPlainObject(config.contractInput) ||
+      !Object.values(config.contractInput).every(value => typeof value === 'string'))
+  ) {
+    throw new Error('contractInput must be a path string or a record of module paths');
   }
 
   validateOutput(config.output);

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ export {
 // Core types
 export type {
   PythonModule,
+  IrContract,
   PythonFunction,
   PythonClass,
   PythonTypeAlias,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,6 +13,13 @@ export interface PythonModule {
   exports: string[];
 }
 
+/** A pinned, versioned JSON IR artifact emitted alongside generated wrappers. */
+export interface IrContract {
+  ir_version: string;
+  module: string;
+  [key: string]: unknown;
+}
+
 /**
  * How a callable is bound on its owning class.
  *
@@ -340,6 +347,11 @@ export interface TywrapOptions {
    * and discovery (IR extraction). Useful for local modules not installed in site-packages.
    */
   pythonImportPath?: string[];
+  /**
+   * Read one pinned IR contract instead of spawning Python. A string applies to
+   * every configured module; a record selects a contract path per module.
+   */
+  contractInput?: string | Record<string, string>;
   output: OutputConfig;
   runtime: RuntimeConfig;
   performance: PerformanceConfig;

--- a/src/tywrap.ts
+++ b/src/tywrap.ts
@@ -16,6 +16,7 @@ import type {
   Parameter,
   PythonType,
   PythonModuleConfig,
+  IrContract,
 } from './types/index.js';
 import { fsUtils, pathUtils, processUtils, isWindows } from './utils/runtime.js';
 import { globalCache } from './utils/cache.js';
@@ -23,7 +24,7 @@ import { resolvePythonExecutable } from './utils/python.js';
 import { computeIrCacheFilename } from './utils/ir-cache.js';
 import { logger } from './utils/logger.js';
 
-const TYWRAP_IR_VERSION = '0.3.0';
+const TYWRAP_IR_VERSION = '0.4.0';
 
 // Collect unknown typing constructs encountered during annotation parsing (per-generate run)
 let unknownTypeNamesCollector: Map<string, number> = new Map();
@@ -66,7 +67,7 @@ export interface GenerateRunOptions {
 
 export interface GenerateFailure {
   module: string;
-  code: 'ir-unavailable';
+  code: 'ir-unavailable' | 'ir-version-mismatch' | 'contract-invalid';
   message: string;
 }
 
@@ -84,6 +85,68 @@ export interface GenerateResult {
 function normalizeForComparison(text: string): string {
   // Avoid false positives from CRLF vs LF (e.g. Windows checkouts)
   return text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+function stableJson(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stableJson);
+  }
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+        .map(([key, child]) => [key, stableJson(child)])
+    );
+  }
+  return value;
+}
+
+function serializeContract(ir: IrContract): string {
+  const contract = { ...ir };
+  delete contract.metadata;
+  return `${JSON.stringify(stableJson(contract), null, 2)}\n`;
+}
+
+function validateIrVersion(
+  ir: unknown,
+  source: string
+): { ir: IrContract | null; error?: string; code?: GenerateFailure['code'] } {
+  if (ir === null || typeof ir !== 'object' || Array.isArray(ir)) {
+    return { ir: null, code: 'contract-invalid', error: `${source} is not a JSON IR object.` };
+  }
+  const contract = ir as IrContract;
+  if (typeof contract.ir_version !== 'string') {
+    return {
+      ir: null,
+      code: 'contract-invalid',
+      error: `${source} is missing its string ir_version.`,
+    };
+  }
+  if (contract.ir_version !== TYWRAP_IR_VERSION) {
+    return {
+      ir: null,
+      code: 'ir-version-mismatch',
+      error: `IR version mismatch: TypeScript expects ${TYWRAP_IR_VERSION}, but ${source} declares ${contract.ir_version}. Regenerate the contract with a matching tywrap_ir.`,
+    };
+  }
+  if (typeof contract.module !== 'string' || contract.module.length === 0) {
+    return { ir: null, code: 'contract-invalid', error: `${source} is missing its module name.` };
+  }
+  const requiredArrays: ReadonlyArray<readonly [string, unknown]> = [
+    ['functions', contract.functions],
+    ['classes', contract.classes],
+    ['type_aliases', contract.type_aliases],
+  ];
+  for (const [field, value] of requiredArrays) {
+    if (!Array.isArray(value)) {
+      return {
+        ir: null,
+        code: 'contract-invalid',
+        error: `${source} is missing required array field ${field}.`,
+      };
+    }
+  }
+  return { ir: contract };
 }
 
 async function safeReadFile(path: string): Promise<string | null> {
@@ -109,13 +172,17 @@ async function fetchAndCacheIr(
   cacheKey: string,
   caching: boolean,
   checkMode: boolean
-): Promise<{ ir: unknown | null; error?: string }> {
+): Promise<{ ir: IrContract | null; error?: string; code?: GenerateFailure['code'] }> {
   let ir: unknown | null = null;
   let irError: string | undefined;
   if (caching && fsUtils.isAvailable() && !checkMode) {
     try {
       const cached = await fsUtils.readFile(pathUtils.join(CACHE_DIR, cacheKey));
-      ir = JSON.parse(cached);
+      const cachedValidation = validateIrVersion(
+        JSON.parse(cached),
+        `Cached Python IR for ${moduleKey}`
+      );
+      ir = cachedValidation.ir;
     } catch {
       ir = null;
     }
@@ -127,13 +194,60 @@ async function fetchAndCacheIr(
     });
     ir = fetchResult.ir;
     irError = fetchResult.error;
-    if (ir && caching && fsUtils.isAvailable() && !checkMode) {
-      try {
-        await fsUtils.writeFile(pathUtils.join(CACHE_DIR, cacheKey), JSON.stringify(ir));
-      } catch {}
-    }
   }
-  return { ir, error: irError };
+  if (!ir) {
+    return { ir: null, error: irError, code: 'ir-unavailable' };
+  }
+  const validated = validateIrVersion(ir, `Python IR for ${moduleKey}`);
+  if (!validated.ir) {
+    return {
+      ir: null,
+      error: irError ?? validated.error,
+      code: validated.code ?? 'ir-unavailable',
+    };
+  }
+  if (caching && fsUtils.isAvailable() && !checkMode) {
+    try {
+      await fsUtils.writeFile(pathUtils.join(CACHE_DIR, cacheKey), JSON.stringify(validated.ir));
+    } catch {}
+  }
+  return { ir: validated.ir };
+}
+
+async function readContractInput(
+  moduleKey: string,
+  contractInput: TywrapOptions['contractInput']
+): Promise<{ ir: IrContract | null; error?: string; code?: GenerateFailure['code'] }> {
+  const inputPath = typeof contractInput === 'string' ? contractInput : contractInput?.[moduleKey];
+  if (!inputPath) {
+    return {
+      ir: null,
+      code: 'contract-invalid',
+      error: `No contractInput path configured for module ${moduleKey}.`,
+    };
+  }
+  try {
+    const parsed = JSON.parse(await fsUtils.readFile(inputPath)) as unknown;
+    const validated = validateIrVersion(parsed, `Contract ${inputPath}`);
+    if (!validated.ir) {
+      return { ir: null, error: validated.error, code: validated.code };
+    }
+    if (validated.ir.module !== moduleKey) {
+      return {
+        ir: null,
+        code: 'contract-invalid',
+        error: `Contract ${inputPath} is for module ${validated.ir.module}, not ${moduleKey}.`,
+      };
+    }
+    return { ir: validated.ir };
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      ir: null,
+      code: 'contract-invalid',
+      error: `Failed to read contract ${inputPath}: ${message}`,
+    };
+  }
 }
 
 /**
@@ -323,20 +437,16 @@ export async function generate(
     unknownTypeNamesCollector = new Map();
     // Resolve module IR via the Python extractor (with optional cache)
     const cacheKey = await computeCacheKey(moduleKey, resolvedOptions);
-    const { ir, error: irError } = await fetchAndCacheIr(
-      moduleKey,
-      resolvedOptions,
-      pythonPath,
-      cacheKey,
-      caching,
-      checkMode
-    );
+    const irResult = resolvedOptions.contractInput
+      ? await readContractInput(moduleKey, resolvedOptions.contractInput)
+      : await fetchAndCacheIr(moduleKey, resolvedOptions, pythonPath, cacheKey, caching, checkMode);
+    const { ir, error: irError } = irResult;
     if (!ir) {
       const message = `No IR produced for module ${moduleKey}${irError ? `: ${irError}` : ''}`;
       warnings.push(message);
       failures.push({
         module: moduleKey,
-        code: 'ir-unavailable',
+        code: irResult.code ?? 'ir-unavailable',
         message,
       });
       continue;
@@ -372,6 +482,10 @@ export async function generate(
     const baseName = moduleModel.name || 'module';
     const filesToEmit: Array<{ path: string; content: string }> = [
       { path: pathUtils.join(outputDir, `${baseName}.generated.ts`), content: gen.typescript },
+      {
+        path: pathUtils.join(outputDir, `${baseName}.contract.json`),
+        content: serializeContract(ir),
+      },
     ];
 
     // Optional .d.ts emission (header-only declarations mirroring exports)
@@ -462,7 +576,7 @@ async function fetchPythonIr(
   try {
     const primary = await execAndParseIr(
       pythonPath,
-      ['-m', 'tywrap_ir', '--module', moduleName, '--ir-version', TYWRAP_IR_VERSION, '--no-pretty'],
+      ['-m', 'tywrap_ir', '--module', moduleName, '--no-pretty'],
       execOptions,
       'tywrap_ir output'
     );
@@ -497,7 +611,7 @@ async function fetchPythonIr(
 
     const fallback = await execAndParseIr(
       pythonPath,
-      [localMain, '--module', moduleName, '--ir-version', TYWRAP_IR_VERSION, '--no-pretty'],
+      [localMain, '--module', moduleName, '--no-pretty'],
       execOptions,
       'tywrap_ir fallback output'
     );

--- a/test/config_loading.test.ts
+++ b/test/config_loading.test.ts
@@ -2,9 +2,16 @@ import { describe, expect, it } from 'vitest';
 import { chmod, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import { loadConfigFile } from '../src/config/index.js';
+import { createConfig, loadConfigFile } from '../src/config/index.js';
 
 describe('config loading', () => {
+  it('accepts record-form contractInput paths', () => {
+    const config = createConfig({
+      contractInput: { math: './generated/math.contract.json' },
+    });
+    expect(config.contractInput).toEqual({ math: './generated/math.contract.json' });
+  });
+
   it('loads a .ts config that imports defineConfig from tywrap', async () => {
     // Why: tywrap is published as ESM, so TS configs that import from 'tywrap' must be evaluated
     // as ESM as well (CommonJS transpilation would try `require('tywrap')` and fail).

--- a/test/fixtures/python/contract_determinism.py
+++ b/test/fixtures/python/contract_determinism.py
@@ -1,0 +1,7 @@
+"""IR fixture whose set repr varies with PYTHONHASHSEED unless canonicalized."""
+
+VALUES = {"beta", "alpha", "gamma"}
+
+
+def values() -> set[str]:
+    return VALUES

--- a/test/ir_contract.test.ts
+++ b/test/ir_contract.test.ts
@@ -1,0 +1,150 @@
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, expect, it } from 'vitest';
+import { generate } from '../src/tywrap.js';
+import { getDefaultPythonPath } from '../src/utils/python.js';
+
+const pythonPath = getDefaultPythonPath();
+
+function options(outputDir: string) {
+  return {
+    pythonModules: { math: { typeHints: 'strict' as const } },
+    output: { dir: outputDir, format: 'esm' as const, declaration: false, sourceMap: false },
+    runtime: { node: { pythonPath } },
+    performance: { caching: false, batching: false, compression: 'none' as const },
+  };
+}
+
+describe('pinned IR contracts', () => {
+  it('writes stable sorted contracts and detects contract drift in check mode', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'tywrap-ir-contract-'));
+    try {
+      const outputDir = join(tempDir, 'generated');
+      const result = await generate(options(outputDir));
+      const contractPath = result.written.find(path => path.endsWith('math.contract.json'));
+      expect(contractPath).toBeDefined();
+
+      const first = await readFile(contractPath as string, 'utf8');
+      const parsed = JSON.parse(first) as Record<string, unknown>;
+      expect(Object.keys(parsed)).toEqual(Object.keys(parsed).sort());
+      expect(parsed).not.toHaveProperty('metadata');
+      await generate(options(outputDir));
+      expect(await readFile(contractPath as string, 'utf8')).toBe(first);
+
+      await writeFile(contractPath as string, '{"drift":true}\n', 'utf8');
+      const check = await generate(options(outputDir), { check: true });
+      expect(check.outOfDate).toContain(contractPath);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('is byte-identical across Python processes with different hash seeds', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'tywrap-ir-contract-seeds-'));
+    const originalSeed = process.env.PYTHONHASHSEED;
+    try {
+      const seededOptions = (outputDir: string) => ({
+        ...options(outputDir),
+        pythonModules: { contract_determinism: { typeHints: 'strict' as const } },
+        pythonImportPath: ['test/fixtures/python'],
+      });
+
+      process.env.PYTHONHASHSEED = '1';
+      await generate(seededOptions(join(tempDir, 'seed-1')));
+      process.env.PYTHONHASHSEED = '987654';
+      await generate(seededOptions(join(tempDir, 'seed-2')));
+
+      const first = await readFile(
+        join(tempDir, 'seed-1', 'contract_determinism.contract.json'),
+        'utf8'
+      );
+      const second = await readFile(
+        join(tempDir, 'seed-2', 'contract_determinism.contract.json'),
+        'utf8'
+      );
+      expect(second).toBe(first);
+    } finally {
+      if (originalSeed === undefined) {
+        delete process.env.PYTHONHASHSEED;
+      } else {
+        process.env.PYTHONHASHSEED = originalSeed;
+      }
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('generates from contractInput without spawning Python', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'tywrap-ir-contract-input-'));
+    try {
+      const outputDir = join(tempDir, 'generated');
+      const first = await generate(options(outputDir));
+      const contractPath = first.written.find(path =>
+        path.endsWith('math.contract.json')
+      ) as string;
+      const originalOutput = await readFile(join(outputDir, 'math.generated.ts'), 'utf8');
+
+      const fromContract = await generate({
+        ...options(outputDir),
+        contractInput: contractPath,
+        runtime: { node: { pythonPath: join(tempDir, 'python-must-not-run') } },
+      });
+      expect(fromContract.failures).toEqual([]);
+      expect(await readFile(join(outputDir, 'math.generated.ts'), 'utf8')).toBe(originalOutput);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails clearly when Python IR reports a different schema version', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'tywrap-ir-contract-version-'));
+    try {
+      const fakePython = join(tempDir, 'fake-python');
+      await writeFile(
+        fakePython,
+        '#!/bin/sh\nprintf \'{"ir_version":"0.3.0","module":"math"}\\n\'\n',
+        'utf8'
+      );
+      await chmod(fakePython, 0o755);
+
+      const result = await generate({
+        ...options(join(tempDir, 'generated')),
+        runtime: { node: { pythonPath: fakePython } },
+      });
+      expect(result.failures).toEqual([
+        expect.objectContaining({
+          code: 'ir-version-mismatch',
+          message: expect.stringContaining(
+            'TypeScript expects 0.4.0, but Python IR for math declares 0.3.0'
+          ),
+        }),
+      ]);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects same-version contracts with missing collection fields', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'tywrap-ir-contract-shape-'));
+    try {
+      const contractPath = join(tempDir, 'malformed.contract.json');
+      await writeFile(
+        contractPath,
+        JSON.stringify({ ir_version: '0.4.0', module: 'math', functions: [] }),
+        'utf8'
+      );
+      const result = await generate({
+        ...options(join(tempDir, 'generated')),
+        contractInput: contractPath,
+      });
+      expect(result.failures).toEqual([
+        expect.objectContaining({
+          code: 'contract-invalid',
+          message: expect.stringContaining('missing required array field classes'),
+        }),
+      ]);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tywrap_ir/tywrap_ir/__init__.py
+++ b/tywrap_ir/tywrap_ir/__init__.py
@@ -5,6 +5,6 @@ __all__ = [
 ]
 
 __version__ = "0.2.1"
-IR_VERSION = "0.3.0"
+IR_VERSION = "0.4.0"
 
 from .ir import extract_module_ir  # noqa: E402

--- a/tywrap_ir/tywrap_ir/ir.py
+++ b/tywrap_ir/tywrap_ir/ir.py
@@ -391,7 +391,13 @@ def _extract_constants(module: Any, module_name: str, include_private: bool) -> 
         is_final = bool(annotation_str and ("Final[" in annotation_str or annotation_str == "Final"))
 
         try:
-            value_repr = repr(value)
+            if isinstance(value, set):
+                value_repr = "set()" if not value else "{" + ", ".join(sorted(repr(item) for item in value)) + "}"
+            elif isinstance(value, frozenset):
+                inner = ", ".join(sorted(repr(item) for item in value))
+                value_repr = f"frozenset({{{inner}}})"
+            else:
+                value_repr = repr(value)
             if len(value_repr) > 200:
                 value_repr = value_repr[:197] + "..."
         except Exception:


### PR DESCRIPTION
## Summary

- Write deterministic `<module>.contract.json` IR artifacts beside generated wrappers.
- Make `generate --check` detect contract drift alongside generated-code drift.
- Add `contractInput` for generating from a pinned artifact without spawning Python.
- Pin the cross-language IR schema at 0.4.0 and fail clearly on version skew.

## BREAKING CHANGE

Generation now produces a contract artifact, and build generation can fail when the installed Python extractor and TypeScript expected IR versions differ. Pinned contracts with a mismatched schema version also fail generation.

Closes #269
