### PR TITLE
test(menagerie): one-call rows, data-driven roundtrips, pinned scientific CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,35 @@ jobs:
           TYWRAP_CODEC_PYTHON: python
         run: npm test -- test/runtime_codec_scientific.test.ts
 
+  optional-scientific-menagerie:
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - name: Install Node dependencies
+        run: npm ci --prefer-offline --no-audit
+      - name: Install pinned scientific dependencies
+        env:
+          PIP_DISABLE_PIP_VERSION_CHECK: '1'
+          PIP_PROGRESS_BAR: 'off'
+        run: |
+          python -m pip install -e tywrap_ir
+          python -m pip install numpy==2.3.5 pandas==3.0.2 pyarrow==24.0.0 scipy==1.16.3 scikit-learn==1.8.0
+          python -m pip install torch==2.10.0 --index-url https://download.pytorch.org/whl/cpu
+      - name: Run pinned scientific menagerie
+        env:
+          TYWRAP_CODEC_PYTHON: python
+        run: npm run test:menagerie
+
   os:
     if: github.event_name != 'schedule'
     runs-on: ${{ matrix.os }}
@@ -333,6 +362,7 @@ jobs:
       - python-suite-core
       - python-suite-data
       - living-app
+      - optional-scientific-menagerie
       - os
       - bun
       - node25-smoke
@@ -346,6 +376,7 @@ jobs:
           if [ "${{ needs.python-suite-core.result }}" != "success" ]; then echo "::error::python-suite-core: ${{ needs.python-suite-core.result }}"; fail=1; fi
           if [ "${{ needs.python-suite-data.result }}" != "success" ]; then echo "::error::python-suite-data: ${{ needs.python-suite-data.result }}"; fail=1; fi
           if [ "${{ needs.living-app.result }}" != "success" ]; then echo "::error::living-app: ${{ needs.living-app.result }}"; fail=1; fi
+          if [ "${{ needs.optional-scientific-menagerie.result }}" != "success" ]; then echo "::error::optional-scientific-menagerie: ${{ needs.optional-scientific-menagerie.result }}"; fail=1; fi
           if [ "${{ needs.os.result }}" != "success" ]; then echo "::error::os: ${{ needs.os.result }}"; fail=1; fi
           if [ "${{ needs.bun.result }}" != "success" ]; then echo "::error::bun: ${{ needs.bun.result }}"; fail=1; fi
           if [ "${{ needs.node25-smoke.result }}" != "success" ]; then echo "::error::node25-smoke: ${{ needs.node25-smoke.result }}"; fail=1; fi

--- a/test/menagerie/__snapshots__/gen.test.ts.snap
+++ b/test/menagerie/__snapshots__/gen.test.ts.snap
@@ -354,6 +354,48 @@ export async function integerBoundaries(): Promise<number[]> {
   return getRuntimeBridge().call<number[]>('fixtures.values_torture', 'integer_boundaries', __args, undefined, __validateinteger_boundariesResult);
 }
 
+const __validateinteger_factorial_30Result = createReturnValidator({"kind":"primitive","type":"number"}, "fixtures.values_torture.integer_factorial_30", __tywrapReturnDefinitions);
+
+export async function integerFactorial_30(): Promise<number> {
+  const __args: unknown[] = [];
+  return getRuntimeBridge().call<number>('fixtures.values_torture', 'integer_factorial_30', __args, undefined, __validateinteger_factorial_30Result);
+}
+
+const __validateinteger_first_roundedResult = createReturnValidator({"kind":"primitive","type":"number"}, "fixtures.values_torture.integer_first_rounded", __tywrapReturnDefinitions);
+
+export async function integerFirstRounded(): Promise<number> {
+  const __args: unknown[] = [];
+  return getRuntimeBridge().call<number>('fixtures.values_torture', 'integer_first_rounded', __args, undefined, __validateinteger_first_roundedResult);
+}
+
+const __validateinteger_first_unsafeResult = createReturnValidator({"kind":"primitive","type":"number"}, "fixtures.values_torture.integer_first_unsafe", __tywrapReturnDefinitions);
+
+export async function integerFirstUnsafe(): Promise<number> {
+  const __args: unknown[] = [];
+  return getRuntimeBridge().call<number>('fixtures.values_torture', 'integer_first_unsafe', __args, undefined, __validateinteger_first_unsafeResult);
+}
+
+const __validateinteger_int64_maxResult = createReturnValidator({"kind":"primitive","type":"number"}, "fixtures.values_torture.integer_int64_max", __tywrapReturnDefinitions);
+
+export async function integerInt64Max(): Promise<number> {
+  const __args: unknown[] = [];
+  return getRuntimeBridge().call<number>('fixtures.values_torture', 'integer_int64_max', __args, undefined, __validateinteger_int64_maxResult);
+}
+
+const __validateinteger_int64_minResult = createReturnValidator({"kind":"primitive","type":"number"}, "fixtures.values_torture.integer_int64_min", __tywrapReturnDefinitions);
+
+export async function integerInt64Min(): Promise<number> {
+  const __args: unknown[] = [];
+  return getRuntimeBridge().call<number>('fixtures.values_torture', 'integer_int64_min', __args, undefined, __validateinteger_int64_minResult);
+}
+
+const __validateinteger_safe_maxResult = createReturnValidator({"kind":"primitive","type":"number"}, "fixtures.values_torture.integer_safe_max", __tywrapReturnDefinitions);
+
+export async function integerSafeMax(): Promise<number> {
+  const __args: unknown[] = [];
+  return getRuntimeBridge().call<number>('fixtures.values_torture', 'integer_safe_max', __args, undefined, __validateinteger_safe_maxResult);
+}
+
 const __validatelone_surrogateResult = createReturnValidator({"kind":"primitive","type":"string"}, "fixtures.values_torture.lone_surrogate", __tywrapReturnDefinitions);
 
 export async function loneSurrogate(): Promise<string> {
@@ -459,6 +501,18 @@ export function generatorValue(): Promise<object>;
 export function intKeyDict(): Promise<{  [key: number]: string; }>;
 
 export function integerBoundaries(): Promise<number[]>;
+
+export function integerFactorial_30(): Promise<number>;
+
+export function integerFirstRounded(): Promise<number>;
+
+export function integerFirstUnsafe(): Promise<number>;
+
+export function integerInt64Max(): Promise<number>;
+
+export function integerInt64Min(): Promise<number>;
+
+export function integerSafeMax(): Promise<number>;
 
 export function loneSurrogate(): Promise<string>;
 

--- a/test/menagerie/fixtures/library_torture.py
+++ b/test/menagerie/fixtures/library_torture.py
@@ -46,3 +46,252 @@ def networkx_tuple_key_shape() -> object:
     graph = nx.Graph()
     graph.add_edge(("left", 1), ("right", 2), weight=3)
     return nx.to_dict_of_dicts(graph)
+
+
+def numpy_zero_dimensional() -> object:
+    import numpy as np
+
+    return np.array(7)
+
+
+def numpy_float16() -> object:
+    import numpy as np
+
+    return np.array([1.5, -2.25], dtype=np.float16)
+
+
+def numpy_bool() -> object:
+    import numpy as np
+
+    return np.array([True, False], dtype=np.bool_)
+
+
+def numpy_int8() -> object:
+    import numpy as np
+
+    return np.array([-128, 127], dtype=np.int8)
+
+
+def numpy_int16() -> object:
+    import numpy as np
+
+    return np.array([-32768, 32767], dtype=np.int16)
+
+
+def numpy_int32() -> object:
+    import numpy as np
+
+    return np.array([-2147483648, 2147483647], dtype=np.int32)
+
+
+def numpy_int64() -> object:
+    import numpy as np
+
+    return np.array([-9223372036854775808, 9223372036854775807], dtype=np.int64)
+
+
+def numpy_datetime64() -> object:
+    import numpy as np
+
+    return np.array(["2024-01-02T03:04:05.123456789"], dtype="datetime64[ns]")
+
+
+def numpy_big_endian() -> object:
+    import numpy as np
+
+    return np.array([1, 2], dtype=">i4")
+
+
+def numpy_structured() -> object:
+    import numpy as np
+
+    return np.array([(1, 2.5)], dtype=[("left", "i4"), ("right", "f4")])
+
+
+def numpy_empty() -> object:
+    import numpy as np
+
+    return np.array([], dtype=np.float64)
+
+
+def numpy_unsafe_int64() -> object:
+    import numpy as np
+
+    return np.array([2**53 + 1], dtype=np.int64)
+
+
+def pandas_nullable_int64() -> object:
+    import pandas as pd
+
+    return pd.DataFrame({"value": pd.Series([1, pd.NA], dtype="Int64")})
+
+
+def pandas_categorical() -> object:
+    import pandas as pd
+
+    return pd.DataFrame({"value": pd.Categorical(["a", "b", "a"])})
+
+
+def pandas_pyarrow_string() -> object:
+    import pandas as pd
+
+    return pd.DataFrame({"value": pd.Series(["a", None], dtype="string[pyarrow]")})
+
+
+def pandas_timezone_aware() -> object:
+    import pandas as pd
+
+    return pd.DataFrame({"when": [pd.Timestamp("2024-01-02T03:04:05", tz="UTC")]})
+
+
+def pandas_multiindex() -> object:
+    import pandas as pd
+
+    index = pd.MultiIndex.from_tuples([("left", 1)], names=["side", "number"])
+    return pd.DataFrame({"value": [3]}, index=index)
+
+
+def pandas_duplicate_labels() -> object:
+    import pandas as pd
+
+    return pd.DataFrame([[1, 2]], columns=["value", "value"])
+
+
+def pandas_empty_frame() -> object:
+    import pandas as pd
+
+    return pd.DataFrame()
+
+
+def scipy_csr() -> object:
+    from scipy import sparse
+
+    return sparse.csr_matrix([[1, 0], [0, 2]])
+
+
+def scipy_csc() -> object:
+    from scipy import sparse
+
+    return sparse.csc_matrix([[1, 0], [0, 2]])
+
+
+def scipy_coo() -> object:
+    from scipy import sparse
+
+    return sparse.coo_matrix([[1, 0], [0, 2]])
+
+
+def scipy_dia() -> object:
+    from scipy import sparse
+
+    return sparse.dia_matrix([[1, 0], [0, 2]])
+
+
+def scipy_bsr() -> object:
+    from scipy import sparse
+
+    return sparse.bsr_matrix([[1, 0], [0, 2]])
+
+
+def scipy_lil() -> object:
+    from scipy import sparse
+
+    return sparse.lil_matrix([[1, 0], [0, 2]])
+
+
+def scipy_dok() -> object:
+    from scipy import sparse
+
+    return sparse.dok_matrix([[1, 0], [0, 2]])
+
+
+def scipy_complex() -> object:
+    from scipy import sparse
+
+    return sparse.csr_matrix([[1 + 2j, 0], [0, 3 + 4j]])
+
+
+def scipy_duplicate_coo() -> object:
+    from scipy import sparse
+
+    return sparse.coo_matrix(([1, 2], ([0, 0], [1, 1])), shape=(2, 2))
+
+
+def scipy_explicit_zeros() -> object:
+    from scipy import sparse
+
+    return sparse.coo_matrix(([0, 2], ([0, 1], [0, 1])), shape=(2, 2))
+
+
+def torch_float32() -> object:
+    import torch
+
+    return torch.tensor([1.5, -2.25], dtype=torch.float32)
+
+
+def torch_float16() -> object:
+    import torch
+
+    return torch.tensor([1.5, -2.25], dtype=torch.float16)
+
+
+def torch_bool() -> object:
+    import torch
+
+    return torch.tensor([True, False], dtype=torch.bool)
+
+
+def torch_int64() -> object:
+    import torch
+
+    return torch.tensor([1, -2], dtype=torch.int64)
+
+
+def torch_scalar() -> object:
+    import torch
+
+    return torch.tensor(7)
+
+
+def torch_bfloat16() -> object:
+    import torch
+
+    return torch.tensor([1.5], dtype=torch.bfloat16)
+
+
+def torch_sparse() -> object:
+    import torch
+
+    return torch.sparse_coo_tensor(torch.tensor([[0], [1]]), torch.tensor([3.0]), (2, 2))
+
+
+def torch_quantized() -> object:
+    import torch
+
+    return torch.quantize_per_tensor(torch.tensor([1.0, 2.0]), 0.1, 0, torch.qint8)
+
+
+def torch_complex() -> object:
+    import torch
+
+    return torch.tensor([1 + 2j, 3 + 4j])
+
+
+def sklearn_simple_estimator() -> object:
+    from sklearn.linear_model import LinearRegression
+
+    return LinearRegression(fit_intercept=False, positive=True)
+
+
+def sklearn_pipeline() -> object:
+    from sklearn.linear_model import LogisticRegression
+    from sklearn.pipeline import Pipeline
+    from sklearn.preprocessing import StandardScaler
+
+    return Pipeline([("scale", StandardScaler()), ("model", LogisticRegression())])
+
+
+def sklearn_tfidf_vectorizer() -> object:
+    from sklearn.feature_extraction.text import TfidfVectorizer
+
+    return TfidfVectorizer()

--- a/test/menagerie/fixtures/values_torture.py
+++ b/test/menagerie/fixtures/values_torture.py
@@ -32,6 +32,30 @@ def integer_boundaries() -> list[int]:
     return [2**53 - 1, 2**53, 2**53 + 1, 2**63, -(2**63), math.factorial(30)]
 
 
+def integer_safe_max() -> int:
+    return 2**53 - 1
+
+
+def integer_first_unsafe() -> int:
+    return 2**53
+
+
+def integer_first_rounded() -> int:
+    return 2**53 + 1
+
+
+def integer_int64_max() -> int:
+    return 2**63 - 1
+
+
+def integer_int64_min() -> int:
+    return -(2**63)
+
+
+def integer_factorial_30() -> int:
+    return math.factorial(30)
+
+
 def bools_and_ints() -> list[bool | int]:
     return [True, False, 0, 1]
 

--- a/test/menagerie/fixtures/values_torture.py
+++ b/test/menagerie/fixtures/values_torture.py
@@ -7,7 +7,9 @@ from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal, localcontext as _localcontext
 from enum import Enum
-from pathlib import Path
+# PurePosixPath keeps str() stable across platforms; WindowsPath stringifies
+# with backslashes and the manifest expectation is a literal.
+from pathlib import PurePosixPath
 from uuid import UUID
 
 
@@ -111,7 +113,7 @@ def decimal_values() -> list[Decimal]:
 def uuid_and_path() -> dict[str, object]:
     return {
         "uuid": UUID("12345678-1234-5678-1234-567812345678"),
-        "path": Path("fixtures/example.txt"),
+        "path": PurePosixPath("fixtures/example.txt"),
     }
 
 

--- a/test/menagerie/manifest.ts
+++ b/test/menagerie/manifest.ts
@@ -5,95 +5,751 @@ export const TIER_ONE_MODULES = ['fixtures.typing_torture', 'fixtures.values_tor
 export const OPTIONAL_LIBRARY_MODULE = 'fixtures.library_torture';
 
 export type CatalogueStatus = 'EXPECTED_OK' | 'KNOWN_LIE' | 'LOUD_FAIL';
+export type CodecPath = 'arrow' | 'json';
+export type OptionalLibrary =
+  | 'numpy'
+  | 'pandas'
+  | 'pyarrow'
+  | 'scipy'
+  | 'torch'
+  | 'sklearn'
+  | 'networkx';
+
+export type CatalogueExpectation =
+  | { kind: 'equal'; value: unknown }
+  | { kind: 'error'; pattern: RegExp }
+  | { kind: 'length'; value: number }
+  | { kind: 'match'; value: object }
+  | { kind: 'set-pair'; value: readonly [readonly unknown[], readonly unknown[]] }
+  | {
+      kind: 'table-rows';
+      value: readonly object[];
+      pandasMetadataIncludes?: readonly string[];
+    };
 
 export interface CatalogueRow {
-  fixture: string;
+  id: string;
+  fixture: 'values_torture' | 'library_torture';
   call: string;
+  functionName: string;
+  args?: readonly unknown[];
   status: CatalogueStatus;
   currentBehavior: string;
+  expected: CatalogueExpectation;
+  codec?: CodecPath;
+  requires?: readonly OptionalLibrary[];
+  featureProbe?: string;
   expectedFix?: string;
 }
 
+function valuesRow(
+  row: Omit<CatalogueRow, 'fixture' | 'functionName'> & { functionName?: string }
+): CatalogueRow {
+  return {
+    fixture: 'values_torture',
+    functionName: row.functionName ?? row.call.replace(/\(.*/, ''),
+    ...row,
+  };
+}
+
+function libraryRow(
+  row: Omit<CatalogueRow, 'fixture' | 'functionName'> & { functionName?: string }
+): CatalogueRow {
+  return {
+    fixture: 'library_torture',
+    functionName: row.functionName ?? row.call.replace(/\(.*/, ''),
+    ...row,
+  };
+}
+
+const error = (pattern: RegExp): CatalogueExpectation => ({ kind: 'error', pattern });
+const equal = (value: unknown): CatalogueExpectation => ({ kind: 'equal', value });
+
 /**
- * Runtime catalogue. Add a row before accepting a newly observed divergence.
- * This makes every supported fixture value exact, loudly rejected, or visible.
+ * Runtime catalogue. Every row is one Python call under one codec configuration.
+ * A row must describe today's behavior, including loss and explicit rejection.
  */
 export const RUNTIME_CATALOGUE: readonly CatalogueRow[] = [
-  {
-    fixture: 'values_torture',
-    call: 'integer_boundaries()',
+  valuesRow({
+    id: 'bools-and-ints',
+    call: 'bools_and_ints()',
+    status: 'EXPECTED_OK',
+    currentBehavior: 'Booleans remain distinct from integer zero and one.',
+    expected: equal([true, false, 0, 1]),
+  }),
+  valuesRow({
+    id: 'finite-float-edges',
+    call: 'finite_float_edges()',
+    status: 'EXPECTED_OK',
+    currentBehavior: 'Negative zero and the smallest positive subnormal survive.',
+    expected: equal([-0, 5e-324]),
+  }),
+  valuesRow({
+    id: 'unicode-text',
+    call: 'unicode_text()',
+    status: 'EXPECTED_OK',
+    currentBehavior: 'Unicode, emoji, and embedded NUL survive.',
+    expected: equal('emoji: 🐍; CJK: 漢字; NUL: \0'),
+  }),
+  valuesRow({
+    id: 'lone-surrogate',
+    call: 'lone_surrogate()',
+    status: 'EXPECTED_OK',
+    currentBehavior: 'A lone UTF-16 surrogate survives with its code unit intact.',
+    expected: equal('\ud800'),
+  }),
+  valuesRow({
+    id: 'megabyte-text',
+    call: 'megabyte_text()',
+    status: 'EXPECTED_OK',
+    currentBehavior: 'A one-megabyte string is delivered in full.',
+    expected: { kind: 'length', value: 1024 * 1024 },
+  }),
+  valuesRow({
+    id: 'deeply-nested',
+    call: 'deeply_nested()',
+    status: 'EXPECTED_OK',
+    currentBehavior: 'One hundred nested list levels survive.',
+    expected: equal(Array.from({ length: 100 }).reduce<unknown>(value => [value], 'leaf')),
+  }),
+  valuesRow({
+    id: 'integer-safe-max',
+    call: 'integer_safe_max()',
+    status: 'EXPECTED_OK',
+    currentBehavior: 'The largest safe JavaScript integer survives exactly.',
+    expected: equal(2 ** 53 - 1),
+  }),
+  valuesRow({
+    id: 'integer-first-unsafe',
+    call: 'integer_first_unsafe()',
     status: 'KNOWN_LIE',
-    currentBehavior: 'Integers above Number.MAX_SAFE_INTEGER lose precision in JavaScript.',
+    currentBehavior: 'The first unsafe integer is delivered as an untagged JavaScript number.',
+    expected: equal(2 ** 53),
     expectedFix: 'Future bigint or tagged-integer transport.',
-  },
-  {
-    fixture: 'values_torture',
+  }),
+  valuesRow({
+    id: 'integer-first-rounded',
+    call: 'integer_first_rounded()',
+    status: 'KNOWN_LIE',
+    currentBehavior: '2^53 + 1 rounds down to 2^53 in JavaScript.',
+    expected: equal(2 ** 53),
+    expectedFix: 'Future bigint or tagged-integer transport.',
+  }),
+  valuesRow({
+    id: 'integer-int64-max',
+    call: 'integer_int64_max()',
+    status: 'KNOWN_LIE',
+    currentBehavior: 'The signed int64 maximum rounds in JavaScript.',
+    expected: equal(2 ** 63),
+    expectedFix: 'Future bigint or tagged-integer transport.',
+  }),
+  valuesRow({
+    id: 'integer-int64-min',
+    call: 'integer_int64_min()',
+    status: 'KNOWN_LIE',
+    currentBehavior: 'The signed int64 minimum is delivered as an unsafe JavaScript number.',
+    expected: equal(-(2 ** 63)),
+    expectedFix: 'Future bigint or tagged-integer transport.',
+  }),
+  valuesRow({
+    id: 'integer-factorial-30',
+    call: 'integer_factorial_30()',
+    status: 'KNOWN_LIE',
+    currentBehavior: 'factorial(30) is delivered as a rounded JavaScript number.',
+    expected: equal(2.6525285981219107e32),
+    expectedFix: 'Future bigint or tagged-integer transport.',
+  }),
+  valuesRow({
+    id: 'empty-values',
     call: 'empty_values()',
     status: 'KNOWN_LIE',
-    currentBehavior:
-      'The empty Python tuple is not represented exactly in the generated tuple type.',
-    expectedFix: 'Future exact empty-tuple typing.',
-  },
-  {
-    fixture: 'values_torture',
+    currentBehavior: 'The empty Python tuple and set both arrive as arrays.',
+    expected: equal([[], [], {}, []]),
+    expectedFix: 'Future exact empty-tuple and set transport.',
+  }),
+  valuesRow({
+    id: 'set-and-frozenset',
     call: 'set_and_frozenset()',
     status: 'EXPECTED_OK',
     currentBehavior: 'Python sets and frozensets are declared and delivered as JavaScript arrays.',
-  },
-  {
-    fixture: 'values_torture',
+    expected: {
+      kind: 'set-pair',
+      value: [
+        [1, 2],
+        ['a', 'b'],
+      ],
+    },
+  }),
+  valuesRow({
+    id: 'int-key-dict',
     call: 'int_key_dict()',
     status: 'KNOWN_LIE',
     currentBehavior: 'Integer keys silently stringify as JSON object keys.',
+    expected: equal({ 1: 'one', 2: 'two' }),
     expectedFix: 'Future tagged-map transport that preserves key types.',
-  },
-  {
-    fixture: 'values_torture',
+  }),
+  valuesRow({
+    id: 'bytes-echo',
     call: 'bytes_echo()',
+    functionName: 'bytes_echo',
+    args: [new Uint8Array([0, 255, 128])],
     status: 'EXPECTED_OK',
     currentBehavior: 'Python bytes are declared and delivered as Uint8Array.',
-  },
-  {
-    fixture: 'values_torture',
-    call: 'temporal_values(), decimal_values(), uuid_and_path()',
+    expected: equal(new Uint8Array([0, 255, 128])),
+  }),
+  valuesRow({
+    id: 'temporal-values',
+    call: 'temporal_values()',
     status: 'KNOWN_LIE',
-    currentBehavior:
-      'Python temporal values, Decimal, UUID, and Path decode as strings or seconds; Decimal is now generated as unknown rather than an undeclared TypeScript leaf.',
+    currentBehavior: 'Temporal values decode as strings or seconds rather than tagged values.',
+    expected: equal({
+      datetime_naive: '2024-01-02T03:04:05',
+      datetime_utc: '2024-01-02T03:04:05+00:00',
+      date: '2024-01-02',
+      time: '03:04:05',
+      timedelta: 172803,
+    }),
     expectedFix: 'Future tagged stdlib-value transport.',
-  },
-  {
-    fixture: 'values_torture',
-    call: 'special_floats(true)',
+  }),
+  valuesRow({
+    id: 'decimal-values',
+    call: 'decimal_values()',
+    status: 'KNOWN_LIE',
+    currentBehavior: 'Decimal values decode as strings.',
+    expected: equal(['0.1', '0.3']),
+    expectedFix: 'Future tagged Decimal transport.',
+  }),
+  valuesRow({
+    id: 'uuid-and-path',
+    call: 'uuid_and_path()',
+    status: 'KNOWN_LIE',
+    currentBehavior: 'UUID and Path values decode as strings.',
+    expected: equal({
+      uuid: '12345678-1234-5678-1234-567812345678',
+      path: 'fixtures/example.txt',
+    }),
+    expectedFix: 'Future tagged UUID and Path transport.',
+  }),
+  ...[
+    ['special-floats', 'special_floats(true)', 'special_floats', [true], /NaN|Infinity|serialize/i],
+    ['tuple-key-dict', 'tuple_key_dict()', 'tuple_key_dict', [], /keys must be str/i],
+    ['enum-member', 'enum_member()', 'enum_member', [], /TrafficLight|serializable/i],
+    ['coroutine-value', 'coroutine_value()', 'coroutine_value', [], /coroutine|serializable/i],
+    ['dataclass-instance', 'dataclass_instance()', 'dataclass_instance', [], /serializable/i],
+    ['complex-value', 'complex_value()', 'complex_value', [], /serializable/i],
+    ['generator-value', 'generator_value()', 'generator_value', [], /serializable/i],
+  ].map(([id, call, functionName, args, pattern]) =>
+    valuesRow({
+      id: id as string,
+      call: call as string,
+      functionName: functionName as string,
+      args: args as unknown[],
+      status: 'LOUD_FAIL',
+      currentBehavior: 'The unsupported value rejects at the bridge boundary.',
+      expected: error(pattern as RegExp),
+    })
+  ),
+
+  // NumPy: Arrow is the default subprocess path; JSON rows pin fallback-only differences.
+  libraryRow({
+    id: 'numpy-0d-arrow',
+    call: 'numpy_zero_dimensional()',
+    codec: 'arrow',
+    requires: ['numpy', 'pyarrow'],
     status: 'LOUD_FAIL',
-    currentBehavior: 'NaN and infinities are rejected by the JSON codec.',
-    expectedFix: 'Future non-finite number representation.',
-  },
-  {
-    fixture: 'values_torture',
-    call: 'tuple_key_dict()',
+    currentBehavior: 'Arrow cannot construct an array from a 0-D ndarray.',
+    expected: error(/Arrow encoding failed for ndarray/i),
+  }),
+  libraryRow({
+    id: 'numpy-0d-json',
+    call: 'numpy_zero_dimensional()',
+    codec: 'json',
+    requires: ['numpy'],
+    status: 'EXPECTED_OK',
+    currentBehavior: 'JSON fallback delivers the scalar value.',
+    expected: equal(7),
+  }),
+  libraryRow({
+    id: 'numpy-float16-arrow',
+    call: 'numpy_float16()',
+    codec: 'arrow',
+    requires: ['numpy', 'pyarrow'],
+    status: 'KNOWN_LIE',
+    currentBehavior: 'Arrow JS exposes float16 storage bits as numbers.',
+    expected: equal([15872, 49280]),
+  }),
+  libraryRow({
+    id: 'numpy-float16-json',
+    call: 'numpy_float16()',
+    codec: 'json',
+    requires: ['numpy'],
+    status: 'EXPECTED_OK',
+    currentBehavior: 'JSON fallback preserves the float16 values as JavaScript numbers.',
+    expected: equal([1.5, -2.25]),
+  }),
+  libraryRow({
+    id: 'numpy-bool',
+    call: 'numpy_bool()',
+    codec: 'arrow',
+    requires: ['numpy', 'pyarrow'],
+    status: 'EXPECTED_OK',
+    currentBehavior: 'Arrow preserves boolean values.',
+    expected: equal([true, false]),
+  }),
+  libraryRow({
+    id: 'numpy-int8',
+    call: 'numpy_int8()',
+    codec: 'arrow',
+    requires: ['numpy', 'pyarrow'],
+    status: 'EXPECTED_OK',
+    currentBehavior: 'Arrow preserves int8 values.',
+    expected: equal([-128, 127]),
+  }),
+  libraryRow({
+    id: 'numpy-int16',
+    call: 'numpy_int16()',
+    codec: 'arrow',
+    requires: ['numpy', 'pyarrow'],
+    status: 'EXPECTED_OK',
+    currentBehavior: 'Arrow preserves int16 values.',
+    expected: equal([-32768, 32767]),
+  }),
+  libraryRow({
+    id: 'numpy-int32',
+    call: 'numpy_int32()',
+    codec: 'arrow',
+    requires: ['numpy', 'pyarrow'],
+    status: 'EXPECTED_OK',
+    currentBehavior: 'Arrow preserves int32 values.',
+    expected: equal([-2147483648, 2147483647]),
+  }),
+  libraryRow({
+    id: 'numpy-int64',
+    call: 'numpy_int64()',
+    codec: 'arrow',
+    requires: ['numpy', 'pyarrow'],
+    status: 'EXPECTED_OK',
+    currentBehavior: 'Arrow preserves int64 values as JavaScript bigint values.',
+    expected: equal([-9223372036854775808n, 9223372036854775807n]),
+  }),
+  libraryRow({
+    id: 'numpy-datetime64-arrow',
+    call: 'numpy_datetime64()',
+    codec: 'arrow',
+    requires: ['numpy', 'pyarrow'],
+    status: 'EXPECTED_OK',
+    currentBehavior: 'Arrow preserves the epoch and ndarray dtype metadata.',
+    expected: equal([1704164645123456789n]),
+  }),
+  libraryRow({
+    id: 'numpy-datetime64-json',
+    call: 'numpy_datetime64()',
+    codec: 'json',
+    requires: ['numpy'],
+    status: 'KNOWN_LIE',
+    currentBehavior: 'JSON fallback emits an untagged epoch integer that rounds in JavaScript.',
+    expected: equal([1704164645123456800]),
+  }),
+  libraryRow({
+    id: 'numpy-big-endian',
+    call: 'numpy_big_endian()',
+    codec: 'arrow',
+    requires: ['numpy', 'pyarrow'],
     status: 'LOUD_FAIL',
-    currentBehavior: 'Tuple dict keys reject through the JSON object-key constraint.',
-    expectedFix: 'Future tagged-map transport.',
-  },
-  {
-    fixture: 'values_torture',
-    call: 'enum_member()',
+    currentBehavior: 'Arrow rejects the byte-swapped dtype.',
+    expected: error(/Arrow encoding failed for ndarray/i),
+  }),
+  libraryRow({
+    id: 'numpy-structured',
+    call: 'numpy_structured()',
+    codec: 'arrow',
+    requires: ['numpy', 'pyarrow'],
     status: 'LOUD_FAIL',
-    currentBehavior: 'Enum instances reject rather than silently collapsing to their value.',
-    expectedFix: 'Future tagged Enum transport.',
-  },
-  {
-    fixture: 'values_torture',
-    call: 'coroutine_value(), dataclass_instance(), complex_value(), generator_value()',
+    currentBehavior: 'Arrow rejects the structured dtype.',
+    expected: error(/Arrow encoding failed for ndarray/i),
+  }),
+  libraryRow({
+    id: 'numpy-empty',
+    call: 'numpy_empty()',
+    codec: 'arrow',
+    requires: ['numpy', 'pyarrow'],
+    status: 'EXPECTED_OK',
+    currentBehavior: 'Arrow preserves an empty one-dimensional array.',
+    expected: equal([]),
+  }),
+  libraryRow({
+    id: 'numpy-unsafe-int64-json',
+    call: 'numpy_unsafe_int64()',
+    codec: 'json',
+    requires: ['numpy'],
+    status: 'KNOWN_LIE',
+    currentBehavior: 'JSON fallback rounds int64 values above 2^53.',
+    expected: equal([2 ** 53]),
+  }),
+
+  // pandas: both paths are present whenever dtype/index fidelity differs.
+  libraryRow({
+    id: 'pandas-nullable-int64-arrow',
+    call: 'pandas_nullable_int64()',
+    codec: 'arrow',
+    requires: ['pandas', 'pyarrow'],
+    status: 'EXPECTED_OK',
+    currentBehavior: 'Arrow preserves nullable integer values.',
+    expected: {
+      kind: 'table-rows',
+      value: [{ value: 1n }, { value: null }],
+      pandasMetadataIncludes: ['"numpy_type": "Int64"'],
+    },
+  }),
+  libraryRow({
+    id: 'pandas-nullable-int64-json',
+    call: 'pandas_nullable_int64()',
+    codec: 'json',
+    requires: ['pandas'],
+    status: 'KNOWN_LIE',
+    currentBehavior: 'JSON preserves values but drops the nullable integer dtype.',
+    expected: equal([{ value: 1 }, { value: null }]),
+  }),
+  libraryRow({
+    id: 'pandas-categorical-arrow',
+    call: 'pandas_categorical()',
+    codec: 'arrow',
+    requires: ['pandas', 'pyarrow'],
+    status: 'EXPECTED_OK',
+    currentBehavior: 'Arrow preserves categorical values and dictionary encoding.',
+    expected: {
+      kind: 'table-rows',
+      value: [{ value: 'a' }, { value: 'b' }, { value: 'a' }],
+      pandasMetadataIncludes: ['"pandas_type": "categorical"'],
+    },
+  }),
+  libraryRow({
+    id: 'pandas-categorical-json',
+    call: 'pandas_categorical()',
+    codec: 'json',
+    requires: ['pandas'],
+    status: 'KNOWN_LIE',
+    currentBehavior: 'JSON preserves values but drops categorical dtype information.',
+    expected: equal([{ value: 'a' }, { value: 'b' }, { value: 'a' }]),
+  }),
+  libraryRow({
+    id: 'pandas-pyarrow-string-arrow',
+    call: 'pandas_pyarrow_string()',
+    codec: 'arrow',
+    requires: ['pandas', 'pyarrow'],
+    featureProbe: 'import pandas as pd; pd.Series(["a"], dtype="string[pyarrow]"); print("1")',
+    status: 'EXPECTED_OK',
+    currentBehavior: 'Arrow preserves string values and nulls.',
+    expected: {
+      kind: 'table-rows',
+      value: [{ value: 'a' }, { value: null }],
+      pandasMetadataIncludes: ['"numpy_type": "string"'],
+    },
+  }),
+  libraryRow({
+    id: 'pandas-pyarrow-string-json',
+    call: 'pandas_pyarrow_string()',
+    codec: 'json',
+    requires: ['pandas', 'pyarrow'],
+    featureProbe: 'import pandas as pd; pd.Series(["a"], dtype="string[pyarrow]"); print("1")',
+    status: 'KNOWN_LIE',
+    currentBehavior: 'JSON preserves values but drops the Arrow-backed string dtype.',
+    expected: equal([{ value: 'a' }, { value: null }]),
+  }),
+  libraryRow({
+    id: 'pandas-timezone-arrow',
+    call: 'pandas_timezone_aware()',
+    codec: 'arrow',
+    requires: ['pandas', 'pyarrow'],
+    status: 'EXPECTED_OK',
+    currentBehavior: 'Arrow preserves the timestamp epoch and timezone schema.',
+    expected: {
+      kind: 'table-rows',
+      value: [{ when: 1704164645000 }],
+      pandasMetadataIncludes: ['"timezone": "UTC"'],
+    },
+  }),
+  libraryRow({
+    id: 'pandas-timezone-json',
+    call: 'pandas_timezone_aware()',
+    codec: 'json',
+    requires: ['pandas'],
+    status: 'KNOWN_LIE',
+    currentBehavior: 'JSON delivers an ISO string but loses timestamp dtype and timezone schema.',
+    expected: equal([{ when: '2024-01-02T03:04:05+00:00' }]),
+  }),
+  libraryRow({
+    id: 'pandas-multiindex-arrow',
+    call: 'pandas_multiindex()',
+    codec: 'arrow',
+    requires: ['pandas', 'pyarrow'],
+    status: 'EXPECTED_OK',
+    currentBehavior: 'Arrow materializes all MultiIndex levels alongside the data.',
+    expected: {
+      kind: 'table-rows',
+      value: [{ value: 3n, side: 'left', number: 1n }],
+      pandasMetadataIncludes: ['"index_columns": ["side", "number"]'],
+    },
+  }),
+  libraryRow({
+    id: 'pandas-multiindex-json',
+    call: 'pandas_multiindex()',
+    codec: 'json',
+    requires: ['pandas'],
+    status: 'KNOWN_LIE',
+    currentBehavior: 'Records-oriented JSON drops the MultiIndex.',
+    expected: equal([{ value: 3 }]),
+  }),
+  libraryRow({
+    id: 'pandas-duplicate-labels-arrow',
+    call: 'pandas_duplicate_labels()',
+    codec: 'arrow',
+    requires: ['pandas', 'pyarrow'],
     status: 'LOUD_FAIL',
-    currentBehavior:
-      'Coroutines and unsupported Python objects reject instead of silently coercing; unsupported return leaves (including complex) are generated as unknown. Local Point stays typed to document intent, while its dataclass instance fails loudly at serialization as the catalogued Class-C residual.',
-  },
-  {
-    fixture: 'library_torture',
-    call: 'numpy_adversarial(), pandas_adversarial(), networkx_tuple_key_shape()',
+    currentBehavior: 'Arrow rejects duplicate DataFrame column labels.',
+    expected: error(/Arrow encoding failed for pandas\.DataFrame/i),
+  }),
+  libraryRow({
+    id: 'pandas-duplicate-labels-json',
+    call: 'pandas_duplicate_labels()',
+    codec: 'json',
+    requires: ['pandas'],
+    status: 'KNOWN_LIE',
+    currentBehavior: 'Records-oriented JSON silently retains only the last duplicate label.',
+    expected: equal([{ value: 2 }]),
+  }),
+  libraryRow({
+    id: 'pandas-empty-frame',
+    call: 'pandas_empty_frame()',
+    codec: 'arrow',
+    requires: ['pandas', 'pyarrow'],
+    status: 'EXPECTED_OK',
+    currentBehavior: 'Arrow delivers an empty table.',
+    expected: {
+      kind: 'table-rows',
+      value: [],
+      pandasMetadataIncludes: ['"columns": []'],
+    },
+  }),
+  libraryRow({
+    id: 'pandas-empty-frame-json',
+    call: 'pandas_empty_frame()',
+    codec: 'json',
+    requires: ['pandas'],
+    status: 'KNOWN_LIE',
+    currentBehavior: 'Records-oriented JSON loses the empty DataFrame schema.',
+    expected: equal([]),
+  }),
+
+  // SciPy sparse markers are JSON-only on both bridge paths.
+  libraryRow({
+    id: 'scipy-csr',
+    call: 'scipy_csr()',
+    requires: ['scipy'],
+    status: 'EXPECTED_OK',
+    currentBehavior: 'CSR structure and stored values are preserved.',
+    expected: {
+      kind: 'match',
+      value: { format: 'csr', shape: [2, 2], data: [1, 2], indices: [0, 1], indptr: [0, 1, 2] },
+    },
+  }),
+  libraryRow({
+    id: 'scipy-csc',
+    call: 'scipy_csc()',
+    requires: ['scipy'],
+    status: 'EXPECTED_OK',
+    currentBehavior: 'CSC structure and stored values are preserved.',
+    expected: {
+      kind: 'match',
+      value: { format: 'csc', shape: [2, 2], data: [1, 2], indices: [0, 1], indptr: [0, 1, 2] },
+    },
+  }),
+  libraryRow({
+    id: 'scipy-coo',
+    call: 'scipy_coo()',
+    requires: ['scipy'],
+    status: 'EXPECTED_OK',
+    currentBehavior: 'COO coordinates and stored values are preserved.',
+    expected: {
+      kind: 'match',
+      value: { format: 'coo', shape: [2, 2], data: [1, 2], row: [0, 1], col: [0, 1] },
+    },
+  }),
+  ...(['dia', 'bsr', 'lil', 'dok'] as const).map(format =>
+    libraryRow({
+      id: `scipy-${format}`,
+      call: `scipy_${format}()`,
+      requires: ['scipy'],
+      status: 'LOUD_FAIL',
+      currentBehavior: `${format.toUpperCase()} is rejected outside the supported CSR/CSC/COO set.`,
+      expected: error(new RegExp(`Unsupported scipy sparse format: ${format}`, 'i')),
+    })
+  ),
+  libraryRow({
+    id: 'scipy-complex',
+    call: 'scipy_complex()',
+    requires: ['scipy'],
     status: 'LOUD_FAIL',
-    currentBehavior:
-      'Nested optional-library values that are not JSON-native reject at the bridge boundary.',
-  },
+    currentBehavior: 'Complex sparse values are rejected explicitly.',
+    expected: error(/Complex scipy sparse matrices are not supported/i),
+  }),
+  libraryRow({
+    id: 'scipy-duplicate-coo',
+    call: 'scipy_duplicate_coo()',
+    requires: ['scipy'],
+    status: 'EXPECTED_OK',
+    currentBehavior: 'Duplicate COO coordinates remain distinct stored entries.',
+    expected: {
+      kind: 'match',
+      value: { format: 'coo', shape: [2, 2], data: [1, 2], row: [0, 0], col: [1, 1] },
+    },
+  }),
+  libraryRow({
+    id: 'scipy-explicit-zeros',
+    call: 'scipy_explicit_zeros()',
+    requires: ['scipy'],
+    status: 'EXPECTED_OK',
+    currentBehavior: 'Explicit zero entries remain stored.',
+    expected: {
+      kind: 'match',
+      value: { format: 'coo', shape: [2, 2], data: [0, 2], row: [0, 1], col: [0, 1] },
+    },
+  }),
+
+  // Torch dense tensors use the nested ndarray Arrow path.
+  libraryRow({
+    id: 'torch-float32',
+    call: 'torch_float32()',
+    requires: ['torch', 'pyarrow'],
+    status: 'EXPECTED_OK',
+    currentBehavior: 'A dense float32 CPU tensor round-trips.',
+    expected: {
+      kind: 'match',
+      value: { data: [1.5, -2.25], shape: [2], dtype: 'torch.float32', device: 'cpu' },
+    },
+  }),
+  libraryRow({
+    id: 'torch-float16-arrow',
+    call: 'torch_float16()',
+    codec: 'arrow',
+    requires: ['torch', 'pyarrow'],
+    status: 'KNOWN_LIE',
+    currentBehavior: 'Arrow JS exposes float16 tensor storage bits as numbers.',
+    expected: {
+      kind: 'match',
+      value: { data: [15872, 49280], shape: [2], dtype: 'torch.float16', device: 'cpu' },
+    },
+    expectedFix: 'Future Arrow float16 decoding that preserves numeric values.',
+  }),
+  libraryRow({
+    id: 'torch-float16-json',
+    call: 'torch_float16()',
+    codec: 'json',
+    requires: ['torch'],
+    status: 'EXPECTED_OK',
+    currentBehavior: 'JSON fallback preserves float16 tensor values.',
+    expected: {
+      kind: 'match',
+      value: { data: [1.5, -2.25], shape: [2], dtype: 'torch.float16', device: 'cpu' },
+    },
+  }),
+  libraryRow({
+    id: 'torch-bool',
+    call: 'torch_bool()',
+    requires: ['torch', 'pyarrow'],
+    status: 'EXPECTED_OK',
+    currentBehavior: 'A dense bool CPU tensor round-trips.',
+    expected: {
+      kind: 'match',
+      value: { data: [true, false], shape: [2], dtype: 'torch.bool', device: 'cpu' },
+    },
+  }),
+  libraryRow({
+    id: 'torch-int64',
+    call: 'torch_int64()',
+    requires: ['torch', 'pyarrow'],
+    status: 'EXPECTED_OK',
+    currentBehavior: 'Safe dense int64 CPU tensor values round-trip as numbers.',
+    expected: {
+      kind: 'match',
+      value: { data: [1, -2], shape: [2], dtype: 'torch.int64', device: 'cpu' },
+    },
+  }),
+  libraryRow({
+    id: 'torch-scalar',
+    call: 'torch_scalar()',
+    requires: ['torch', 'pyarrow'],
+    status: 'LOUD_FAIL',
+    currentBehavior: 'The nested 0-D ndarray fails on the Arrow path.',
+    expected: error(/Arrow encoding failed for ndarray/i),
+  }),
+  libraryRow({
+    id: 'torch-bfloat16',
+    call: 'torch_bfloat16()',
+    requires: ['torch', 'pyarrow'],
+    status: 'LOUD_FAIL',
+    currentBehavior: 'NumPy conversion rejects bfloat16.',
+    expected: error(/Failed to convert torch\.Tensor to numpy/i),
+  }),
+  libraryRow({
+    id: 'torch-sparse',
+    call: 'torch_sparse()',
+    requires: ['torch'],
+    status: 'LOUD_FAIL',
+    currentBehavior: 'Sparse tensor layouts are rejected explicitly.',
+    expected: error(/sparse tensors are not supported/i),
+  }),
+  libraryRow({
+    id: 'torch-quantized',
+    call: 'torch_quantized()',
+    requires: ['torch'],
+    featureProbe: 'import torch; print("1" if hasattr(torch, "quantize_per_tensor") else "0")',
+    status: 'LOUD_FAIL',
+    currentBehavior: 'Quantized tensors are rejected explicitly.',
+    expected: error(/quantized tensors are not supported/i),
+  }),
+  libraryRow({
+    id: 'torch-complex',
+    call: 'torch_complex()',
+    requires: ['torch'],
+    status: 'LOUD_FAIL',
+    currentBehavior: 'Complex tensors are rejected explicitly.',
+    expected: error(/complex tensors are not supported/i),
+  }),
+
+  libraryRow({
+    id: 'sklearn-simple-estimator',
+    call: 'sklearn_simple_estimator()',
+    requires: ['sklearn'],
+    status: 'EXPECTED_OK',
+    currentBehavior: 'Plain estimator parameters serialize as metadata.',
+    expected: {
+      kind: 'match',
+      value: { className: 'LinearRegression', params: { fit_intercept: false, positive: true } },
+    },
+  }),
+  libraryRow({
+    id: 'sklearn-pipeline',
+    call: 'sklearn_pipeline()',
+    requires: ['sklearn'],
+    status: 'LOUD_FAIL',
+    currentBehavior: 'Pipeline steps contain nested estimators and reject.',
+    expected: error(/param 'steps' is not JSON-serializable/i),
+  }),
+  libraryRow({
+    id: 'sklearn-tfidf-vectorizer',
+    call: 'sklearn_tfidf_vectorizer()',
+    requires: ['sklearn'],
+    status: 'LOUD_FAIL',
+    currentBehavior: 'The dtype type-object parameter rejects.',
+    expected: error(/param 'dtype' is not JSON-serializable/i),
+  }),
+  libraryRow({
+    id: 'networkx-tuple-key-shape',
+    call: 'networkx_tuple_key_shape()',
+    requires: ['networkx'],
+    status: 'LOUD_FAIL',
+    currentBehavior: 'Tuple-key graph dictionaries reject at the JSON object-key boundary.',
+    expected: error(/keys must be str|JSON encoding failed/i),
+  }),
 ];

--- a/test/menagerie/roundtrip.test.ts
+++ b/test/menagerie/roundtrip.test.ts
@@ -1,18 +1,47 @@
 import { existsSync } from 'node:fs';
 import { delimiter, join } from 'node:path';
-import { describe, expect, it, afterEach } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { NodeBridge } from '../../src/runtime/node.js';
 import { isNodejs } from '../../src/utils/runtime.js';
-import { PYTHON_AVAILABLE, PYTHON } from '../helpers/python-probe.js';
-import { RUNTIME_CATALOGUE } from './manifest.js';
+import {
+  hasPythonModule,
+  pythonExprTruthy,
+  PYTHON,
+  PYTHON_AVAILABLE,
+} from '../helpers/python-probe.js';
+import {
+  type CatalogueExpectation,
+  type CatalogueRow,
+  type OptionalLibrary,
+  RUNTIME_CATALOGUE,
+} from './manifest.js';
 
 const scriptPath = join(process.cwd(), 'runtime', 'python_bridge.py');
 const fixturesRoot = join(process.cwd(), 'test', 'menagerie');
 const bridgeAvailable = isNodejs() && PYTHON_AVAILABLE && existsSync(scriptPath);
-const timeoutMs = 15_000;
+const timeoutMs = process.env.CI ? 60_000 : 20_000;
 let bridge: NodeBridge | undefined;
 
-function createBridge(env: Record<string, string | undefined> = {}): NodeBridge {
+const requiredLibraries = new Set(RUNTIME_CATALOGUE.flatMap(row => row.requires ?? []));
+const libraryAvailability = new Map<OptionalLibrary, boolean>(
+  [...requiredLibraries].map(library => [library, hasPythonModule(library)])
+);
+const featureAvailability = new Map(
+  RUNTIME_CATALOGUE.filter(row => row.featureProbe).map(row => [
+    row.id,
+    pythonExprTruthy(row.featureProbe as string),
+  ])
+);
+
+function rowAvailable(row: CatalogueRow): boolean {
+  return (
+    bridgeAvailable &&
+    (row.requires ?? []).every(library => libraryAvailability.get(library) === true) &&
+    (!row.featureProbe || featureAvailability.get(row.id) === true)
+  );
+}
+
+function createBridge(row: CatalogueRow): NodeBridge {
   const inherited = process.env.PYTHONPATH;
   return new NodeBridge({
     scriptPath,
@@ -20,119 +49,98 @@ function createBridge(env: Record<string, string | undefined> = {}): NodeBridge 
     timeoutMs,
     env: {
       PYTHONPATH: inherited ? `${fixturesRoot}${delimiter}${inherited}` : fixturesRoot,
-      ...env,
+      ...(row.codec === 'json' ? { TYWRAP_CODEC_FALLBACK: 'json' } : {}),
     },
   });
 }
 
-async function callValues<T>(functionName: string, args: unknown[] = []): Promise<T> {
-  bridge ??= createBridge();
-  return bridge.call<T>('fixtures.values_torture', functionName, args);
+interface ArrowTableLike {
+  schema?: { metadata?: Map<string, string> };
+  toArray(): unknown[];
 }
 
-/**
- * CURRENT RUNTIME CATALOGUE
- *
- * | fixture | call | status | current delivery |
- * | --- | --- | --- | --- |
- * | values_torture | echo_int(), bools_and_ints(), finite_float_edges() | EXPECTED_OK | safe integers, booleans, -0, and subnormal float survive |
- * | values_torture | unicode_text(), lone_surrogate(), megabyte_text(), deeply_nested() | EXPECTED_OK | text and 100-level nesting survive |
- * | values_torture | bytes_echo() | EXPECTED_OK | wrapper and bridge both use Uint8Array |
- * | values_torture | integer_boundaries() | KNOWN_LIE | unsafe integers lose precision |
- * | values_torture | empty_values() | KNOWN_LIE | empty tuple typing remains inexact |
- * | values_torture | set_and_frozenset() | EXPECTED_OK | set/frozenset are declared and delivered as arrays |
- * | values_torture | int_key_dict() | KNOWN_LIE | integer object keys stringify |
- * | values_torture | temporal_values(), decimal_values(), uuid_and_path() | KNOWN_LIE | values become strings or seconds |
- * | values_torture | special_floats(true) | LOUD_FAIL | non-finite numbers reject |
- * | values_torture | tuple_key_dict() | LOUD_FAIL | tuple object key rejects |
- * | values_torture | enum_member() | LOUD_FAIL | Enum instance rejects |
- * | values_torture | coroutine_value(), dataclass_instance(), complex_value(), generator_value() | LOUD_FAIL | unsupported objects reject |
- */
-describe.skipIf(!bridgeAvailable)('menagerie runtime gate', () => {
+function asArrowTable(value: unknown): ArrowTableLike {
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    !('toArray' in value) ||
+    typeof value.toArray !== 'function'
+  ) {
+    throw new TypeError('Expected an Arrow table result');
+  }
+  return value as ArrowTableLike;
+}
+
+function tableRows(value: ArrowTableLike): unknown[] {
+  return Array.from(value.toArray(), (row: unknown) => {
+    if (typeof row === 'object' && row !== null) {
+      return Object.fromEntries(Object.entries(row));
+    }
+    return row;
+  });
+}
+
+function assertResolvedValue(value: unknown, expected: CatalogueExpectation): void {
+  switch (expected.kind) {
+    case 'equal':
+      expect(value).toEqual(expected.value);
+      return;
+    case 'length':
+      expect(value).toHaveLength(expected.value);
+      return;
+    case 'match':
+      expect(value).toMatchObject(expected.value);
+      return;
+    case 'set-pair': {
+      expect(value).toHaveLength(2);
+      const pair = value as unknown[][];
+      expect(pair[0]).toEqual(expect.arrayContaining([...expected.value[0]]));
+      expect(pair[1]).toEqual(expect.arrayContaining([...expected.value[1]]));
+      return;
+    }
+    case 'table-rows': {
+      const table = asArrowTable(value);
+      expect(tableRows(table)).toEqual(expected.value);
+      const pandasMetadata = table.schema?.metadata?.get('pandas');
+      for (const fragment of expected.pandasMetadataIncludes ?? []) {
+        expect(pandasMetadata).toContain(fragment);
+      }
+      return;
+    }
+    case 'error':
+      throw new Error('LOUD_FAIL row unexpectedly resolved');
+  }
+}
+
+describe('menagerie runtime catalogue', () => {
   afterEach(async () => {
     await bridge?.dispose();
     bridge = undefined;
   });
 
-  it(
-    'keeps exact values exact where the JSON bridge has a faithful representation',
-    async () => {
-      await expect(callValues('echo_int', [2 ** 53 - 1])).resolves.toBe(2 ** 53 - 1);
-      await expect(callValues('bools_and_ints')).resolves.toEqual([true, false, 0, 1]);
+  for (const row of RUNTIME_CATALOGUE) {
+    it.skipIf(!rowAvailable(row))(
+      `${row.id} [${row.status}] ${row.call}${row.codec ? ` via ${row.codec}` : ''}`,
+      async () => {
+        bridge = createBridge(row);
+        const result = bridge.call(`fixtures.${row.fixture}`, row.functionName, [
+          ...(row.args ?? []),
+        ]);
 
-      const finite = await callValues<number[]>('finite_float_edges');
-      expect(Object.is(finite[0], -0)).toBe(true);
-      expect(finite[1]).toBe(5e-324);
-      await expect(callValues('unicode_text')).resolves.toBe('emoji: 🐍; CJK: 漢字; NUL: \0');
-      await expect(callValues('deeply_nested')).resolves.toEqual(
-        Array.from({ length: 100 }).reduce<unknown>(value => [value], 'leaf')
-      );
-      await expect(callValues('bytes_echo', [new Uint8Array([0, 255, 128])])).resolves.toEqual(
-        new Uint8Array([0, 255, 128])
-      );
-      const surrogate = await callValues<string>('lone_surrogate');
-      expect(surrogate).toHaveLength(1);
-      expect(surrogate.charCodeAt(0)).toBe(0xd800);
-      await expect(callValues<string>('megabyte_text')).resolves.toHaveLength(1024 * 1024);
-    },
-    timeoutMs
-  );
+        if (row.expected.kind === 'error') {
+          await expect(result).rejects.toThrow(row.expected.pattern);
+          return;
+        }
 
-  it(
-    'catalogues scalar representation conversions explicitly',
-    async () => {
-      await expect(callValues('temporal_values')).resolves.toEqual({
-        datetime_naive: '2024-01-02T03:04:05',
-        datetime_utc: '2024-01-02T03:04:05+00:00',
-        date: '2024-01-02',
-        time: '03:04:05',
-        timedelta: 172803,
-      });
-      await expect(callValues('decimal_values')).resolves.toEqual(['0.1', '0.3']);
-      await expect(callValues('uuid_and_path')).resolves.toEqual({
-        uuid: '12345678-1234-5678-1234-567812345678',
-        path: join('fixtures', 'example.txt'),
-      });
-    },
-    timeoutMs
-  );
+        assertResolvedValue(await result, row.expected);
+      },
+      timeoutMs
+    );
+  }
 
-  it(
-    'documents known lies without treating them as exact round trips',
-    async () => {
-      const values = await callValues<number[]>('integer_boundaries');
-      expect(values).toEqual([
-        2 ** 53 - 1,
-        2 ** 53,
-        2 ** 53,
-        2 ** 63,
-        -(2 ** 63),
-        2.6525285981219107e32,
-      ]);
-
-      await expect(callValues('empty_values')).resolves.toEqual([[], [], {}, []]);
-      const sets = await callValues<unknown[]>('set_and_frozenset');
-      expect(sets).toHaveLength(2);
-      expect(sets[0]).toEqual(expect.arrayContaining([1, 2]));
-      expect(sets[1]).toEqual(expect.arrayContaining(['a', 'b']));
-      await expect(callValues('int_key_dict')).resolves.toEqual({ 1: 'one', 2: 'two' });
-      expect(RUNTIME_CATALOGUE.filter(row => row.status === 'KNOWN_LIE')).toHaveLength(4);
-    },
-    timeoutMs
-  );
-
-  it(
-    'fails loudly for values the transport cannot faithfully encode',
-    async () => {
-      await expect(callValues('special_floats', [true])).rejects.toThrow(/NaN|Infinity|serialize/i);
-      await expect(callValues('tuple_key_dict')).rejects.toThrow(/keys must be str/i);
-      await expect(callValues('enum_member')).rejects.toThrow(/TrafficLight|serializable/i);
-      await expect(callValues('coroutine_value')).rejects.toThrow(/coroutine|serializable/i);
-      await expect(callValues('dataclass_instance')).rejects.toThrow(/serializable/i);
-      await expect(callValues('complex_value')).rejects.toThrow(/serializable/i);
-      await expect(callValues('generator_value')).rejects.toThrow(/serializable/i);
-      expect(RUNTIME_CATALOGUE.filter(row => row.status === 'LOUD_FAIL')).toHaveLength(5);
-    },
-    timeoutMs
-  );
+  it('keeps status and executable expectation categories aligned', () => {
+    for (const row of RUNTIME_CATALOGUE) {
+      expect(row.expected.kind === 'error', row.id).toBe(row.status === 'LOUD_FAIL');
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Test-and-CI-only PR. Makes the menagerie an executable truth table for codec behavior ahead of the 0.10 codec correctness series. No runtime, codec, or generator code changes.

- Split grouped manifest rows so each row is one Python call with one expected status. The catalogue now has 79 rows: 34 honest, 21 known lies, 24 loud failures.
- New coverage: NumPy 0-D/float16/bool/int widths/datetime64/endian/structured/unsafe int64; pandas nullable Int64/categorical/pyarrow strings/timezone/MultiIndex/duplicate labels/empty frames with distinct Arrow and JSON truth; SciPy duplicate coordinates and explicit zeros; Torch dtype rows (float16 over Arrow is a newly recorded known lie); sklearn Pipeline and TfidfVectorizer loud rows.
- `roundtrip.test.ts` now emits one named Vitest case per manifest row instead of aggregate status counts, so any behavior flip fails with the row name.
- New `optional-scientific-menagerie` CI job with pinned numpy 2.3.5, pandas 3.0.2, pyarrow 24.0.0, scipy 1.16.3, scikit-learn 1.8.0, torch 2.10.0 (CPU). Included in the `required` aggregation.

Rows assert current main behavior. The upcoming codec validation PR will flip specific rows (0-D Arrow, for one) and those flips will show up as named test edits in that PR.

## Verification

- Menagerie: 88 passed locally against the pinned versions
- `npm run check:all`: 1,331 passed, 94 skipped
- Independent review: no findings