### PR TITLE
feat(runtime): validate all six scientific marker returns

### DIFF
--- a/src/core/generator.ts
+++ b/src/core/generator.ts
@@ -512,6 +512,21 @@ export class CodeGenerator {
           if (leaf === 'ndarray' || leaf === 'NDArray' || full.includes('numpy')) {
             return { kind: 'marker', marker: 'ndarray' };
           }
+          if (
+            ['csr_matrix', 'csc_matrix', 'coo_matrix', 'spmatrix'].includes(leaf) &&
+            (!current.module || current.module.startsWith('scipy'))
+          ) {
+            return { kind: 'marker', marker: 'scipy.sparse' };
+          }
+          if (leaf === 'Tensor' && (!current.module || current.module.startsWith('torch'))) {
+            return { kind: 'marker', marker: 'torch.tensor' };
+          }
+          if (
+            leaf === 'BaseEstimator' &&
+            (!current.module || current.module.startsWith('sklearn'))
+          ) {
+            return { kind: 'marker', marker: 'sklearn.estimator' };
+          }
           return definitions.has(leaf) ? { kind: 'ref', name: leaf } : { kind: 'any' };
         }
         case 'typevar':

--- a/src/runtime/validators.ts
+++ b/src/runtime/validators.ts
@@ -34,12 +34,29 @@ export type ReturnSchema =
     }
   | { kind: 'union'; options: ReturnSchema[] }
   | { kind: 'ref'; name: string }
-  | { kind: 'marker'; marker: 'dataframe' | 'series' | 'ndarray'; dims?: number; dtype?: string };
+  | {
+      kind: 'marker';
+      marker:
+        | 'dataframe'
+        | 'series'
+        | 'ndarray'
+        | 'scipy.sparse'
+        | 'torch.tensor'
+        | 'sklearn.estimator';
+      dims?: number;
+      dtype?: string;
+    };
 
 export type ReturnValidator<T = unknown> = (result: T) => T;
 
 export interface DecodedShapeMetadata {
-  marker: 'dataframe' | 'series' | 'ndarray';
+  marker:
+    | 'dataframe'
+    | 'series'
+    | 'ndarray'
+    | 'scipy.sparse'
+    | 'torch.tensor'
+    | 'sklearn.estimator';
   dims?: number;
   dtype?: string;
 }
@@ -66,13 +83,7 @@ export function describeReceivedShape(value: unknown): string {
   if (value === undefined) {
     return 'undefined';
   }
-  if (value instanceof Uint8Array) {
-    return `Uint8Array(${value.byteLength})`;
-  }
-  if (Array.isArray(value)) {
-    return `array(${value.length})`;
-  }
-  if (typeof value === 'object') {
+  if (isObjectLike(value)) {
     const marker = decodedShapeMetadata.get(value);
     if (marker) {
       const details = [marker.dims === undefined ? undefined : `${marker.dims}d`, marker.dtype]
@@ -80,6 +91,14 @@ export function describeReceivedShape(value: unknown): string {
         .join(', ');
       return `${marker.marker}${details ? ` (${details})` : ''}`;
     }
+  }
+  if (value instanceof Uint8Array) {
+    return `Uint8Array(${value.byteLength})`;
+  }
+  if (Array.isArray(value)) {
+    return `array(${value.length})`;
+  }
+  if (typeof value === 'object') {
     const name = (value as { constructor?: { name?: unknown } }).constructor?.name;
     return typeof name === 'string' && name !== 'Object' ? name : 'object';
   }

--- a/src/utils/codec.ts
+++ b/src/utils/codec.ts
@@ -858,14 +858,17 @@ const decodeScipySparseEnvelope: EnvelopeHandler = value => {
     }
     assertIndexArrayInRange(row, rows, 'row');
     assertIndexArrayInRange(col, cols, 'col');
-    return {
-      format,
-      shape,
-      data,
-      row,
-      col,
-      dtype,
-    } satisfies SparseMatrix;
+    return tagDecodedShape(
+      {
+        format,
+        shape,
+        data,
+        row,
+        col,
+        dtype,
+      } satisfies SparseMatrix,
+      { marker: 'scipy.sparse', dims: shape.length, dtype }
+    );
   }
 
   const indices = value.indices;
@@ -919,14 +922,17 @@ const decodeScipySparseEnvelope: EnvelopeHandler = value => {
     );
   }
   assertIndexArrayInRange(indices, minorAxis, 'indices');
-  return {
-    format,
-    shape,
-    data,
-    indices,
-    indptr,
-    dtype,
-  } satisfies SparseMatrix;
+  return tagDecodedShape(
+    {
+      format,
+      shape,
+      data,
+      indices,
+      indptr,
+      dtype,
+    } satisfies SparseMatrix,
+    { marker: 'scipy.sparse', dims: shape.length, dtype }
+  );
 };
 
 /** Product of a shape's dimensions (the element count). [] (scalar) -> 1. */
@@ -1010,9 +1016,19 @@ const decodeTorchTensorEnvelope: EnvelopeHandler = <T>(
 
   const decoded = recurse(nested);
   if (isPromiseLike(decoded)) {
-    return decoded.then(data => ({ data, shape, dtype, device })) as Promise<T | unknown>;
+    return decoded.then(data =>
+      tagDecodedShape({ data, shape, dtype, device } satisfies TorchTensor, {
+        marker: 'torch.tensor',
+        dims: shape?.length,
+        dtype,
+      })
+    ) as Promise<T | unknown>;
   }
-  return { data: decoded, shape, dtype, device } satisfies TorchTensor;
+  return tagDecodedShape({ data: decoded, shape, dtype, device } satisfies TorchTensor, {
+    marker: 'torch.tensor',
+    dims: shape?.length,
+    dtype,
+  });
 };
 
 /**
@@ -1101,12 +1117,15 @@ const decodeSklearnEstimatorEnvelope: EnvelopeHandler = value => {
     throw new Error('Invalid sklearn.estimator envelope: version must be a string when provided');
   }
   const version = typeof versionValue === 'string' ? versionValue : undefined;
-  return {
-    className,
-    module,
-    version,
-    params,
-  } satisfies SklearnEstimator;
+  return tagDecodedShape(
+    {
+      className,
+      module,
+      version,
+      params,
+    } satisfies SklearnEstimator,
+    { marker: 'sklearn.estimator' }
+  );
 };
 
 // Why: dispatch over the __tywrap__ typeTag instead of a long if-chain so each type's

--- a/test/generator.test.ts
+++ b/test/generator.test.ts
@@ -118,6 +118,42 @@ describe('CodeGenerator', () => {
     expect(code.typescript).toContain('{"kind":"any"}');
   });
 
+  it('emits provenance marker schemas for SciPy, Torch, and sklearn returns', () => {
+    const makeFunction = (name: string, returnType: any): any => ({
+      name,
+      signature: { parameters: [], returnType, isAsync: false, isGenerator: false },
+      decorators: [],
+      isAsync: false,
+      isGenerator: false,
+      returnType,
+      parameters: [],
+    });
+    const code = gen.generateModuleDefinition({
+      name: 'scientific',
+      functions: [
+        makeFunction('sparse', {
+          kind: 'custom',
+          name: 'csr_matrix',
+          module: 'scipy.sparse',
+        }),
+        makeFunction('tensor', { kind: 'custom', name: 'Tensor', module: 'torch' }),
+        makeFunction('estimator', {
+          kind: 'custom',
+          name: 'BaseEstimator',
+          module: 'sklearn.base',
+        }),
+      ],
+      classes: [],
+      typeAliases: [],
+      imports: [],
+      exports: [],
+    });
+
+    expect(code.typescript).toContain('{"kind":"marker","marker":"scipy.sparse"}');
+    expect(code.typescript).toContain('{"kind":"marker","marker":"torch.tensor"}');
+    expect(code.typescript).toContain('{"kind":"marker","marker":"sklearn.estimator"}');
+  });
+
   it('serializes tuple types as TS tuples', () => {
     const code = gen.generateFunctionWrapper(
       {

--- a/test/runtime_codec.test.ts
+++ b/test/runtime_codec.test.ts
@@ -16,6 +16,7 @@ import {
   type DecodedValue,
   type ArrowTable,
 } from '../src/utils/codec.js';
+import { createReturnValidator } from '../src/runtime/validators.js';
 
 describe('Cross-Runtime Data Transfer Codec', () => {
   let originalAtob: typeof globalThis.atob | undefined;
@@ -468,6 +469,12 @@ describe('Cross-Runtime Data Transfer Codec', () => {
         indptr: [0, 1, 2],
         dtype: 'float64',
       });
+      expect(
+        createReturnValidator(
+          { kind: 'marker', marker: 'scipy.sparse', dims: 2, dtype: 'float64' },
+          'fixture.sparse'
+        )(result)
+      ).toBe(result);
     });
 
     it('should reject invalid sparse matrix envelopes', async () => {
@@ -536,6 +543,12 @@ describe('Cross-Runtime Data Transfer Codec', () => {
         dtype: 'float32',
         device: 'cpu',
       });
+      expect(
+        createReturnValidator(
+          { kind: 'marker', marker: 'torch.tensor', dims: 1, dtype: 'float32' },
+          'fixture.tensor'
+        )(result)
+      ).toBe(result);
     });
 
     it('should await nested Arrow ndarray decoding', async () => {
@@ -568,6 +581,12 @@ describe('Cross-Runtime Data Transfer Codec', () => {
         dtype: 'float32',
         device: 'cpu',
       });
+      expect(
+        createReturnValidator(
+          { kind: 'marker', marker: 'torch.tensor', dims: 1, dtype: 'float32' },
+          'fixture.tensor'
+        )(result)
+      ).toBe(result);
     });
 
     it('should fail with an actionable error when apache-arrow is absent (nested)', async () => {
@@ -691,6 +710,12 @@ describe('Cross-Runtime Data Transfer Codec', () => {
         version: '1.4.2',
         params: { fit_intercept: true },
       });
+      expect(
+        createReturnValidator(
+          { kind: 'marker', marker: 'sklearn.estimator' },
+          'fixture.estimator'
+        )(result)
+      ).toBe(result);
     });
 
     it('should reject invalid sklearn estimator envelopes', async () => {

--- a/test/runtime_return_validation.test.ts
+++ b/test/runtime_return_validation.test.ts
@@ -7,6 +7,7 @@ import { HttpBridge } from '../src/runtime/http.js';
 import { NodeBridge } from '../src/runtime/node.js';
 import {
   createReturnValidator,
+  describeReceivedShape,
   tagDecodedShape,
   type ReturnSchema,
 } from '../src/runtime/validators.js';
@@ -93,6 +94,91 @@ describe('generated return validators', () => {
         'fixture.matrix'
       )(array)
     ).toThrow(BridgeValidationError);
+  });
+
+  it('checks scientific marker, dimension, and dtype provenance', () => {
+    const sparse = tagDecodedShape(
+      {},
+      {
+        marker: 'scipy.sparse',
+        dims: 2,
+        dtype: 'float64',
+      }
+    );
+    expect(
+      createReturnValidator(
+        { kind: 'marker', marker: 'scipy.sparse', dims: 2, dtype: 'float64' },
+        'fixture.sparse'
+      )(sparse)
+    ).toBe(sparse);
+    expect(() =>
+      createReturnValidator(
+        { kind: 'marker', marker: 'torch.tensor', dims: 2, dtype: 'float64' },
+        'fixture.sparse'
+      )(sparse)
+    ).toThrow(BridgeValidationError);
+    expect(() =>
+      createReturnValidator(
+        { kind: 'marker', marker: 'scipy.sparse', dims: 1, dtype: 'float64' },
+        'fixture.sparse'
+      )(sparse)
+    ).toThrow(BridgeValidationError);
+    expect(() =>
+      createReturnValidator(
+        { kind: 'marker', marker: 'scipy.sparse', dims: 2, dtype: 'int64' },
+        'fixture.sparse'
+      )(sparse)
+    ).toThrow(BridgeValidationError);
+
+    const tensor = tagDecodedShape(
+      {},
+      {
+        marker: 'torch.tensor',
+        dims: 1,
+        dtype: 'float32',
+      }
+    );
+    expect(
+      createReturnValidator(
+        { kind: 'marker', marker: 'torch.tensor', dims: 1, dtype: 'float32' },
+        'fixture.tensor'
+      )(tensor)
+    ).toBe(tensor);
+    expect(() =>
+      createReturnValidator(
+        { kind: 'marker', marker: 'torch.tensor', dims: 2, dtype: 'float32' },
+        'fixture.tensor'
+      )(tensor)
+    ).toThrow(BridgeValidationError);
+    expect(() =>
+      createReturnValidator(
+        { kind: 'marker', marker: 'torch.tensor', dims: 1, dtype: 'float64' },
+        'fixture.tensor'
+      )(tensor)
+    ).toThrow(BridgeValidationError);
+
+    const estimator = tagDecodedShape({}, { marker: 'sklearn.estimator' });
+    expect(
+      createReturnValidator(
+        { kind: 'marker', marker: 'sklearn.estimator' },
+        'fixture.estimator'
+      )(estimator)
+    ).toBe(estimator);
+    expect(() =>
+      createReturnValidator(
+        { kind: 'marker', marker: 'scipy.sparse' },
+        'fixture.estimator'
+      )(estimator)
+    ).toThrow(BridgeValidationError);
+  });
+
+  it('describes tagged ndarray arrays from provenance before their generic array shape', () => {
+    const array = tagDecodedShape([[1, 2]], {
+      marker: 'ndarray',
+      dims: 2,
+      dtype: 'float64',
+    });
+    expect(describeReceivedShape(array)).toBe('ndarray (2d, float64)');
   });
 
   it('terminates on a recursive forward reference', () => {


### PR DESCRIPTION
## Summary

Second PR of the 0.10 codec correctness series. Runtime return validation and provenance now cover all six envelope markers instead of three.

- Decoded scipy.sparse, torch.tensor, and sklearn.estimator values carry provenance (from validated payload facts), matching the existing dataframe/series/ndarray mechanism.
- Generated wrappers emit `ReturnSchema.kind='marker'` for scipy sparse, torch.Tensor, and sklearn BaseEstimator returns; the validator checks marker equality plus dims/dtype where the marker carries them.
- `describeReceivedShape()` reports stored provenance metadata before the generic `array(n)` fallback.

No producer, protocol, manifest, or config changes.

## Review

Built by codex sol; independent terra review: no findings.

## Verification

- Targeted tests: 92 passed; menagerie: 88 passed
- `npm run check:all`: 1,349 passed, 94 skipped