### PR TITLE
feat(codec): decode nested scientific envelopes

### DIFF
--- a/src/runtime/bridge-codec.ts
+++ b/src/runtime/bridge-codec.ts
@@ -77,6 +77,10 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return proto === Object.prototype || proto === null;
 }
 
+function isPlainArray(value: unknown): value is unknown[] {
+  return Array.isArray(value) && Object.getPrototypeOf(value) === Array.prototype;
+}
+
 /**
  * Build a path string for error messages.
  */
@@ -105,6 +109,29 @@ function scientificMarkerFrom(value: unknown, errorMessage: string): string | un
     return SCIENTIFIC_MARKERS.has(value.__tywrap__) ? value.__tywrap__ : undefined;
   }
   return undefined;
+}
+
+function containsScientificEnvelope(value: unknown): boolean {
+  const pending: unknown[] = [value];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (isPlainArray(current)) {
+      for (const item of current) {
+        pending.push(item);
+      }
+      continue;
+    }
+    if (!isPlainObject(current)) {
+      continue;
+    }
+    if (typeof current.__tywrap__ === 'string') {
+      return SCIENTIFIC_MARKERS.has(current.__tywrap__);
+    }
+    for (const item of Object.values(current)) {
+      pending.push(item);
+    }
+  }
+  return false;
 }
 
 /**
@@ -627,6 +654,13 @@ export class BridgeCodec {
    */
   decodeResponse<T>(payload: string): T {
     const result = this.parseResponseResult(payload);
+
+    if (containsScientificEnvelope(result)) {
+      throw new BridgeCodecError('scientific envelopes require decodeResponseAsync', {
+        codecPhase: 'decode',
+        valueType: 'scientific-envelope',
+      });
+    }
 
     // Post-decode validation for special floats if enabled
     this.assertNoSpecialFloats(result);

--- a/src/utils/codec.ts
+++ b/src/utils/codec.ts
@@ -1220,7 +1220,12 @@ async function decodeEnvelopeAsync<T>(
    * serialized independently, and this decoder does not restore alias identity.
    */
   const visit = (current: unknown, depth: number, path: string): MaybePromise<T | unknown> => {
-    recordVisit(depth, path);
+    // Only containers consume the traversal budget. Primitive leaves are already
+    // bounded by the payload byte cap, and counting them would reject large plain
+    // arrays that decoded fine before recursion existed.
+    if (isPlainArray(current) || isPlainObject(current)) {
+      recordVisit(depth, path);
+    }
 
     if (
       isPlainObject(current) &&

--- a/src/utils/codec.ts
+++ b/src/utils/codec.ts
@@ -1201,6 +1201,29 @@ async function decodeEnvelopeAsync<T>(
 ): Promise<T | unknown> {
   let visitedNodes = 0;
 
+  type DecodeTarget =
+    | { container: unknown[]; key: number }
+    | { container: Record<string, unknown>; key: string };
+
+  interface ArrayFrame {
+    kind: 'array';
+    container: unknown[];
+    depth: number;
+    path: string;
+    nextIndex: number;
+  }
+
+  interface ObjectFrame {
+    kind: 'object';
+    container: Record<string, unknown>;
+    depth: number;
+    path: string;
+    entries: [string, unknown][];
+    nextIndex: number;
+  }
+
+  type DecodeFrame = ArrayFrame | ObjectFrame;
+
   const recordVisit = (depth: number, path: string): void => {
     visitedNodes += 1;
     if (visitedNodes > MAX_DECODE_NODES) {
@@ -1215,117 +1238,153 @@ async function decodeEnvelopeAsync<T>(
     }
   };
 
+  const prefixHandlerError = (error: unknown, path: string): never => {
+    if (path === 'result') {
+      throw error;
+    }
+    throw new Error(
+      `Scientific envelope decode failed at ${path}: ${error instanceof Error ? error.message : String(error)}`
+    );
+  };
+
+  const assignDecoded = (target: DecodeTarget, original: unknown, decoded: unknown): void => {
+    if (decoded !== original) {
+      if (Array.isArray(target.container)) {
+        target.container[target.key as number] = decoded;
+      } else {
+        target.container[target.key as string] = decoded;
+      }
+    }
+  };
+
+  const settleDecoded = async (
+    decoded: PromiseLike<T | unknown>,
+    original: unknown,
+    target: DecodeTarget,
+    path: string
+  ): Promise<void> => {
+    let resolved: T | unknown;
+    try {
+      resolved = await decoded;
+    } catch (error) {
+      return prefixHandlerError(error, path);
+    }
+    assignDecoded(target, original, resolved);
+  };
+
+  const decodeSingle = (item: unknown, depth: number, path: string): MaybePromise<T | unknown> => {
+    // Handlers sometimes decode a required child envelope themselves (currently
+    // torch.tensor.value). Keep that single-envelope recursion unchanged.
+    const recurseSingle: (nested: unknown) => MaybePromise<T | unknown> = nested => {
+      const nestedPath = decodePath(path, 'value');
+      recordVisit(depth + 1, nestedPath);
+      return decodeEnvelopeCore(nested, decodeArrow, recurseSingle);
+    };
+    return decodeEnvelopeCore(item, decodeArrow, recurseSingle);
+  };
+
+  const frames: DecodeFrame[] = [];
+  const pending: Promise<void>[] = [];
+
+  const visit = (current: unknown, depth: number, path: string, target?: DecodeTarget): void => {
+    const plainArray = isPlainArray(current);
+    const plainObject = isPlainObject(current);
+
+    // Only containers consume the traversal budget. Primitive leaves are already
+    // bounded by the payload byte cap, and counting them would reject large plain
+    // arrays that decoded fine before recursion existed.
+    if (plainArray || plainObject) {
+      recordVisit(depth, path);
+    }
+
+    if (plainObject && typeof current.__tywrap__ === 'string') {
+      if (!ENVELOPE_HANDLERS.has(current.__tywrap__)) {
+        return;
+      }
+
+      let decoded: MaybePromise<T | unknown>;
+      try {
+        decoded = decodeSingle(current, depth, path);
+      } catch (error) {
+        return prefixHandlerError(error, path);
+      }
+      if (isPromiseLike(decoded)) {
+        if (target) {
+          pending.push(settleDecoded(decoded, current, target, path));
+        } else {
+          pending.push(settleDecoded(decoded, current, { container: root, key: 'value' }, path));
+        }
+      } else if (target) {
+        assignDecoded(target, current, decoded);
+      } else if (decoded !== current) {
+        root.value = decoded;
+      }
+      return;
+    }
+
+    if (plainArray) {
+      frames.push({ kind: 'array', container: current, depth, path, nextIndex: 0 });
+    } else if (plainObject) {
+      frames.push({
+        kind: 'object',
+        container: current,
+        depth,
+        path,
+        entries: Object.entries(current),
+        nextIndex: 0,
+      });
+    }
+  };
+
   /**
    * Values have copy semantics across the bridge: repeated Python references are
    * serialized independently, and this decoder does not restore alias identity.
    */
-  const visit = (current: unknown, depth: number, path: string): MaybePromise<T | unknown> => {
-    // Only containers consume the traversal budget. Primitive leaves are already
-    // bounded by the payload byte cap, and counting them would reject large plain
-    // arrays that decoded fine before recursion existed.
-    if (isPlainArray(current) || isPlainObject(current)) {
-      recordVisit(depth, path);
+  const root: { value: unknown } = { value };
+  visit(value, 0, 'result');
+
+  const visitChild = (
+    item: unknown,
+    key: string | number,
+    target: DecodeTarget,
+    frame: DecodeFrame
+  ): void => {
+    try {
+      visit(item, frame.depth + 1, decodePath(frame.path, key), target);
+    } catch (error) {
+      pending.push(Promise.reject(error));
     }
-
-    if (
-      isPlainObject(current) &&
-      typeof current.__tywrap__ === 'string' &&
-      !ENVELOPE_HANDLERS.has(current.__tywrap__)
-    ) {
-      return current;
-    }
-
-    // Handlers sometimes decode a required child envelope themselves (currently
-    // torch.tensor.value). Keep that single-envelope recursion unchanged.
-    const decodeSingle = (item: unknown): MaybePromise<T | unknown> => {
-      const recurseSingle: (nested: unknown) => MaybePromise<T | unknown> = nested => {
-        const nestedPath = decodePath(path, 'value');
-        recordVisit(depth + 1, nestedPath);
-        return decodeEnvelopeCore(nested, decodeArrow, recurseSingle);
-      };
-      return decodeEnvelopeCore(item, decodeArrow, recurseSingle);
-    };
-
-    const visitDecoded = (decoded: unknown): MaybePromise<T | unknown> => {
-      if (isPlainArray(decoded)) {
-        const pending: Promise<void>[] = [];
-        decoded.forEach((item, index) => {
-          let next: MaybePromise<T | unknown>;
-          try {
-            next = visit(item, depth + 1, decodePath(path, index));
-          } catch (error) {
-            pending.push(Promise.reject(error));
-            return;
-          }
-          if (isPromiseLike(next)) {
-            pending.push(
-              Promise.resolve(next).then(resolved => {
-                if (resolved !== item) {
-                  decoded[index] = resolved;
-                }
-              })
-            );
-          } else if (next !== item) {
-            decoded[index] = next;
-          }
-        });
-        return pending.length > 0 ? Promise.all(pending).then(() => decoded) : decoded;
-      }
-      if (isPlainObject(decoded)) {
-        const output = decoded;
-        const pending: PromiseLike<void>[] = [];
-        for (const [key, item] of Object.entries(decoded)) {
-          let next: MaybePromise<T | unknown>;
-          try {
-            next = visit(item, depth + 1, decodePath(path, key));
-          } catch (error) {
-            pending.push(Promise.reject(error));
-            continue;
-          }
-          if (isPromiseLike(next)) {
-            pending.push(
-              Promise.resolve(next).then(resolved => {
-                if (resolved !== item) {
-                  output[key] = resolved;
-                }
-              })
-            );
-          } else if (next !== item) {
-            output[key] = next;
-          }
-        }
-        return pending.length > 0 ? Promise.all(pending).then(() => output) : output;
-      }
-      return decoded;
-    };
-
-    if (
-      isPlainObject(current) &&
-      typeof current.__tywrap__ === 'string' &&
-      ENVELOPE_HANDLERS.has(current.__tywrap__)
-    ) {
-      const prefixHandlerError = (error: unknown): never => {
-        if (path === 'result') {
-          throw error;
-        }
-        throw new Error(
-          `Scientific envelope decode failed at ${path}: ${error instanceof Error ? error.message : String(error)}`
-        );
-      };
-
-      let decoded: MaybePromise<T | unknown>;
-      try {
-        decoded = decodeSingle(current);
-      } catch (error) {
-        return prefixHandlerError(error);
-      }
-      return isPromiseLike(decoded) ? Promise.resolve(decoded).catch(prefixHandlerError) : decoded;
-    }
-
-    return visitDecoded(current);
   };
 
-  return await visit(value, 0, 'result');
+  while (frames.length > 0) {
+    const frame = frames[frames.length - 1];
+    if (!frame) {
+      break;
+    }
+    if (
+      frame.nextIndex >= (frame.kind === 'array' ? frame.container.length : frame.entries.length)
+    ) {
+      frames.pop();
+      continue;
+    }
+
+    const index = frame.nextIndex;
+    frame.nextIndex += 1;
+    if (frame.kind === 'array') {
+      visitChild(frame.container[index], index, { container: frame.container, key: index }, frame);
+    } else {
+      const entry = frame.entries[index];
+      if (entry) {
+        const [key, item] = entry;
+        visitChild(item, key, { container: frame.container, key }, frame);
+      }
+    }
+  }
+
+  if (pending.length > 0) {
+    await Promise.all(pending);
+  }
+  return root.value;
 }
 
 /**

--- a/src/utils/codec.ts
+++ b/src/utils/codec.ts
@@ -1141,7 +1141,7 @@ const ENVELOPE_HANDLERS: ReadonlyMap<string, EnvelopeHandler> = new Map([
   ['sklearn.estimator', decodeSklearnEstimatorEnvelope],
 ]);
 
-const MAX_DECODE_DEPTH = 64;
+const MAX_DECODE_DEPTH = 2048;
 const MAX_DECODE_NODES = 1_000_000;
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -1231,8 +1231,7 @@ async function decodeEnvelopeAsync<T>(
     }
 
     // Handlers sometimes decode a required child envelope themselves (currently
-    // torch.tensor.value). Keep that single-envelope recursion unchanged; the
-    // generic container walk happens after the handler returns.
+    // torch.tensor.value). Keep that single-envelope recursion unchanged.
     const decodeSingle = (item: unknown): MaybePromise<T | unknown> => {
       const recurseSingle: (nested: unknown) => MaybePromise<T | unknown> = nested => {
         const nestedPath = decodePath(path, 'value');
@@ -1244,17 +1243,25 @@ async function decodeEnvelopeAsync<T>(
 
     const visitDecoded = (decoded: unknown): MaybePromise<T | unknown> => {
       if (isPlainArray(decoded)) {
-        const items = decoded.map((item, index) => visit(item, depth + 1, decodePath(path, index)));
-        const pending: PromiseLike<void>[] = [];
-        items.forEach((item, index) => {
-          if (isPromiseLike(item)) {
+        const pending: Promise<void>[] = [];
+        decoded.forEach((item, index) => {
+          let next: MaybePromise<T | unknown>;
+          try {
+            next = visit(item, depth + 1, decodePath(path, index));
+          } catch (error) {
+            pending.push(Promise.reject(error));
+            return;
+          }
+          if (isPromiseLike(next)) {
             pending.push(
-              item.then(resolved => {
-                decoded[index] = resolved;
+              Promise.resolve(next).then(resolved => {
+                if (resolved !== item) {
+                  decoded[index] = resolved;
+                }
               })
             );
-          } else {
-            decoded[index] = item;
+          } else if (next !== item) {
+            decoded[index] = next;
           }
         });
         return pending.length > 0 ? Promise.all(pending).then(() => decoded) : decoded;
@@ -1263,14 +1270,22 @@ async function decodeEnvelopeAsync<T>(
         const output = decoded;
         const pending: PromiseLike<void>[] = [];
         for (const [key, item] of Object.entries(decoded)) {
-          const next = visit(item, depth + 1, decodePath(path, key));
+          let next: MaybePromise<T | unknown>;
+          try {
+            next = visit(item, depth + 1, decodePath(path, key));
+          } catch (error) {
+            pending.push(Promise.reject(error));
+            continue;
+          }
           if (isPromiseLike(next)) {
             pending.push(
-              next.then(resolved => {
-                output[key] = resolved;
+              Promise.resolve(next).then(resolved => {
+                if (resolved !== item) {
+                  output[key] = resolved;
+                }
               })
             );
-          } else {
+          } else if (next !== item) {
             output[key] = next;
           }
         }
@@ -1279,8 +1294,30 @@ async function decodeEnvelopeAsync<T>(
       return decoded;
     };
 
-    const decoded = isPlainObject(current) ? decodeSingle(current) : current;
-    return isPromiseLike(decoded) ? decoded.then(visitDecoded) : visitDecoded(decoded);
+    if (
+      isPlainObject(current) &&
+      typeof current.__tywrap__ === 'string' &&
+      ENVELOPE_HANDLERS.has(current.__tywrap__)
+    ) {
+      const prefixHandlerError = (error: unknown): never => {
+        if (path === 'result') {
+          throw error;
+        }
+        throw new Error(
+          `Scientific envelope decode failed at ${path}: ${error instanceof Error ? error.message : String(error)}`
+        );
+      };
+
+      let decoded: MaybePromise<T | unknown>;
+      try {
+        decoded = decodeSingle(current);
+      } catch (error) {
+        return prefixHandlerError(error);
+      }
+      return isPromiseLike(decoded) ? Promise.resolve(decoded).catch(prefixHandlerError) : decoded;
+    }
+
+    return visitDecoded(current);
   };
 
   return await visit(value, 0, 'result');

--- a/src/utils/codec.ts
+++ b/src/utils/codec.ts
@@ -1141,6 +1141,28 @@ const ENVELOPE_HANDLERS: ReadonlyMap<string, EnvelopeHandler> = new Map([
   ['sklearn.estimator', decodeSklearnEstimatorEnvelope],
 ]);
 
+const MAX_DECODE_DEPTH = 64;
+const MAX_DECODE_NODES = 1_000_000;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!isObject(value)) {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function isPlainArray(value: unknown): value is unknown[] {
+  return Array.isArray(value) && Object.getPrototypeOf(value) === Array.prototype;
+}
+
+function decodePath(base: string, key: string | number): string {
+  if (typeof key === 'number') {
+    return `${base}[${key}]`;
+  }
+  return /^[A-Za-z_$][\w$]*$/.test(key) ? `${base}.${key}` : `${base}[${JSON.stringify(key)}]`;
+}
+
 function decodeEnvelopeCore<T>(
   value: unknown,
   decodeArrow: (bytes: Uint8Array) => MaybePromise<T>,
@@ -1177,9 +1199,91 @@ async function decodeEnvelopeAsync<T>(
   value: unknown,
   decodeArrow: (bytes: Uint8Array) => Promise<T>
 ): Promise<T | unknown> {
-  const recurse: (value: unknown) => MaybePromise<T | unknown> = v =>
-    decodeEnvelopeCore(v, decodeArrow, recurse);
-  return await decodeEnvelopeCore(value, decodeArrow, recurse);
+  let visitedNodes = 0;
+
+  const recordVisit = (depth: number, path: string): void => {
+    visitedNodes += 1;
+    if (visitedNodes > MAX_DECODE_NODES) {
+      throw new Error(
+        `Scientific envelope decode maximum visited nodes ${MAX_DECODE_NODES} exceeded at ${path}`
+      );
+    }
+    if (depth > MAX_DECODE_DEPTH) {
+      throw new Error(
+        `Scientific envelope decode maximum depth ${MAX_DECODE_DEPTH} exceeded at ${path}`
+      );
+    }
+  };
+
+  /**
+   * Values have copy semantics across the bridge: repeated Python references are
+   * serialized independently, and this decoder does not restore alias identity.
+   */
+  const visit = (current: unknown, depth: number, path: string): MaybePromise<T | unknown> => {
+    recordVisit(depth, path);
+
+    if (
+      isPlainObject(current) &&
+      typeof current.__tywrap__ === 'string' &&
+      !ENVELOPE_HANDLERS.has(current.__tywrap__)
+    ) {
+      return current;
+    }
+
+    // Handlers sometimes decode a required child envelope themselves (currently
+    // torch.tensor.value). Keep that single-envelope recursion unchanged; the
+    // generic container walk happens after the handler returns.
+    const decodeSingle = (item: unknown): MaybePromise<T | unknown> => {
+      const recurseSingle: (nested: unknown) => MaybePromise<T | unknown> = nested => {
+        const nestedPath = decodePath(path, 'value');
+        recordVisit(depth + 1, nestedPath);
+        return decodeEnvelopeCore(nested, decodeArrow, recurseSingle);
+      };
+      return decodeEnvelopeCore(item, decodeArrow, recurseSingle);
+    };
+
+    const visitDecoded = (decoded: unknown): MaybePromise<T | unknown> => {
+      if (isPlainArray(decoded)) {
+        const items = decoded.map((item, index) => visit(item, depth + 1, decodePath(path, index)));
+        const pending: PromiseLike<void>[] = [];
+        items.forEach((item, index) => {
+          if (isPromiseLike(item)) {
+            pending.push(
+              item.then(resolved => {
+                decoded[index] = resolved;
+              })
+            );
+          } else {
+            decoded[index] = item;
+          }
+        });
+        return pending.length > 0 ? Promise.all(pending).then(() => decoded) : decoded;
+      }
+      if (isPlainObject(decoded)) {
+        const output = decoded;
+        const pending: PromiseLike<void>[] = [];
+        for (const [key, item] of Object.entries(decoded)) {
+          const next = visit(item, depth + 1, decodePath(path, key));
+          if (isPromiseLike(next)) {
+            pending.push(
+              next.then(resolved => {
+                output[key] = resolved;
+              })
+            );
+          } else {
+            output[key] = next;
+          }
+        }
+        return pending.length > 0 ? Promise.all(pending).then(() => output) : output;
+      }
+      return decoded;
+    };
+
+    const decoded = isPlainObject(current) ? decodeSingle(current) : current;
+    return isPromiseLike(decoded) ? decoded.then(visitDecoded) : visitDecoded(decoded);
+  };
+
+  return await visit(value, 0, 'result');
 }
 
 /**

--- a/test/bridge-codec.test.ts
+++ b/test/bridge-codec.test.ts
@@ -432,6 +432,34 @@ describe('decodeResponse - Basic', () => {
     expect(codec.decodeResponse<null>('null')).toBe(null);
   });
 
+  it('rejects recognized scientific envelopes at root and nested locations', () => {
+    const envelope = {
+      __tywrap__: 'ndarray',
+      codecVersion: 1,
+      encoding: 'json',
+      data: [1],
+      shape: [1],
+      dtype: 'int64',
+    };
+
+    expect(() => codec.decodeResponse(JSON.stringify(envelope))).toThrow(
+      'scientific envelopes require decodeResponseAsync'
+    );
+    expect(() => codec.decodeResponse(JSON.stringify({ items: [{ matrix: envelope }] }))).toThrow(
+      'scientific envelopes require decodeResponseAsync'
+    );
+  });
+
+  it('keeps unknown scientific markers on the sync path', () => {
+    const value = {
+      item: {
+        __tywrap__: 'future.marker',
+        value: { __tywrap__: 'ndarray', encoding: 'json', data: [1] },
+      },
+    };
+    expect(codec.decodeResponse(JSON.stringify(value))).toEqual(value);
+  });
+
   it('throws BridgeCodecError on invalid JSON', () => {
     expect(() => codec.decodeResponse('not json')).toThrow(BridgeCodecError);
     expect(() => codec.decodeResponse('not json')).toThrow(/JSON parse failed/);
@@ -578,6 +606,31 @@ describe('decodeResponseAsync - Arrow Integration', () => {
     const payload = JSON.stringify({ simple: 'data' });
     const result = await codec.decodeResponseAsync<{ simple: string }>(payload);
     expect(result).toEqual({ simple: 'data' });
+  });
+
+  it('decodes producer-shaped scientific envelopes nested in RPC results', async () => {
+    const payload = JSON.stringify({
+      id: 1,
+      protocol: 'tywrap/1',
+      result: {
+        items: [
+          {
+            matrix: {
+              __tywrap__: 'ndarray',
+              codecVersion: 1,
+              encoding: 'json',
+              data: [1, 2],
+              shape: [2],
+              dtype: 'int64',
+            },
+          },
+        ],
+      },
+    });
+
+    await expect(codec.decodeResponseAsync(payload)).resolves.toEqual({
+      items: [{ matrix: [1, 2] }],
+    });
   });
 
   it('labels v1 scientific-envelope validation failures without Arrow wording', async () => {

--- a/test/menagerie/manifest.ts
+++ b/test/menagerie/manifest.ts
@@ -109,9 +109,9 @@ export const RUNTIME_CATALOGUE: readonly CatalogueRow[] = [
   valuesRow({
     id: 'deeply-nested',
     call: 'deeply_nested()',
-    status: 'LOUD_FAIL',
-    currentBehavior: 'Values deeper than the decoder limit reject with their exact path.',
-    expected: error(/maximum depth 64 exceeded at result(?:\[0\]){65}/i),
+    status: 'EXPECTED_OK',
+    currentBehavior: 'A 100-deep list survives and ends in the original leaf value.',
+    expected: equal(Array.from({ length: 100 }).reduce<unknown>(value => [value], 'leaf')),
   }),
   valuesRow({
     id: 'integer-safe-max',

--- a/test/menagerie/manifest.ts
+++ b/test/menagerie/manifest.ts
@@ -109,9 +109,9 @@ export const RUNTIME_CATALOGUE: readonly CatalogueRow[] = [
   valuesRow({
     id: 'deeply-nested',
     call: 'deeply_nested()',
-    status: 'EXPECTED_OK',
-    currentBehavior: 'One hundred nested list levels survive.',
-    expected: equal(Array.from({ length: 100 }).reduce<unknown>(value => [value], 'leaf')),
+    status: 'LOUD_FAIL',
+    currentBehavior: 'Values deeper than the decoder limit reject with their exact path.',
+    expected: error(/maximum depth 64 exceeded at result(?:\[0\]){65}/i),
   }),
   valuesRow({
     id: 'integer-safe-max',

--- a/test/runtime_codec.test.ts
+++ b/test/runtime_codec.test.ts
@@ -914,6 +914,27 @@ describe('Cross-Runtime Data Transfer Codec', () => {
       });
     });
 
+    it('walks deeply nested plain arrays without using the JavaScript call stack', async () => {
+      const nestedArray = (depth: number): unknown[] => {
+        const value: unknown[] = [];
+        let cursor = value;
+        for (let index = 0; index < depth; index += 1) {
+          const next: unknown[] = [];
+          cursor.push(next);
+          cursor = next;
+        }
+        return value;
+      };
+      const tooDeep = nestedArray(2049);
+      const withinBound = nestedArray(2000);
+      const path = `result${'[0]'.repeat(2049)}`;
+
+      await expect(decodeValueAsync(tooDeep)).rejects.toMatchObject({
+        message: `Scientific envelope decode maximum depth 2048 exceeded at ${path}`,
+      });
+      await expect(decodeValueAsync(withinBound)).resolves.toBe(withinBound);
+    });
+
     it('counts a torch tensor nested ndarray against the depth bound', async () => {
       const value: Record<string, unknown> = {};
       let cursor = value;

--- a/test/runtime_codec.test.ts
+++ b/test/runtime_codec.test.ts
@@ -939,8 +939,14 @@ describe('Cross-Runtime Data Transfer Codec', () => {
       });
     });
 
-    it('rejects more than 1,000,000 visited nodes with the exact path', async () => {
-      const value = new Array<null>(1_000_000).fill(null);
+    it('does not spend the node budget on primitive leaves', async () => {
+      const value = new Array<number>(1_000_000).fill(0);
+
+      await expect(decodeValueAsync(value)).resolves.toBe(value);
+    });
+
+    it('rejects more than 1,000,000 visited container nodes with the exact path', async () => {
+      const value = Array.from({ length: 1_000_000 }, () => []);
 
       await expect(decodeValueAsync(value)).rejects.toMatchObject({
         message:

--- a/test/runtime_codec.test.ts
+++ b/test/runtime_codec.test.ts
@@ -826,7 +826,47 @@ describe('Cross-Runtime Data Transfer Codec', () => {
       });
     });
 
-    it('decodes an envelope inside a decoded container value', async () => {
+    it('handles an earlier rejecting async envelope when a later sibling throws synchronously', async () => {
+      let releaseLoader: (() => void) | undefined;
+      _setLazyArrowLoaderForTesting(
+        () =>
+          new Promise((_, reject) => {
+            releaseLoader = () => reject(new Error('deferred loader rejection'));
+          })
+      );
+      const unhandled: unknown[] = [];
+      const onUnhandled = (reason: unknown): void => {
+        unhandled.push(reason);
+      };
+      process.on('unhandledRejection', onUnhandled);
+
+      try {
+        const decoding = decodeValueAsync([
+          {
+            __tywrap__: 'dataframe',
+            codecVersion: 1,
+            encoding: 'arrow',
+            b64: '',
+          },
+          {
+            __tywrap__: 'ndarray',
+            codecVersion: 1,
+            encoding: 'json',
+            data: [1],
+            dtype: 'int64',
+          },
+        ]);
+
+        await expect(decoding).rejects.toThrow('shape at path shape');
+        releaseLoader?.();
+        await new Promise(resolve => setTimeout(resolve, 0));
+        expect(unhandled).toEqual([]);
+      } finally {
+        process.off('unhandledRejection', onUnhandled);
+      }
+    });
+
+    it('treats decoded envelope output as terminal', async () => {
       const value = {
         __tywrap__: 'dataframe' as const,
         codecVersion: 1,
@@ -843,32 +883,41 @@ describe('Cross-Runtime Data Transfer Codec', () => {
       };
 
       await expect(decodeValueAsync(value)).resolves.toEqual({
-        matrix: [
-          [1, 2],
-          [3, 4],
-        ],
+        matrix: ndarray(
+          [
+            [1, 2],
+            [3, 4],
+          ],
+          [2, 2]
+        ),
       });
     });
 
-    it('rejects values deeper than 64 with the exact path', async () => {
+    it('does not count decoded ndarray payload elements as visited nodes', async () => {
+      const data = new Array<number>(1_000_001).fill(1);
+
+      await expect(decodeValueAsync(ndarray(data))).resolves.toBe(data);
+    });
+
+    it('rejects values deeper than 2048 with the exact path', async () => {
       const value: Record<string, unknown> = {};
       let cursor = value;
-      for (let depth = 0; depth < 65; depth += 1) {
+      for (let depth = 0; depth < 2049; depth += 1) {
         const next: Record<string, unknown> = {};
         cursor.next = next;
         cursor = next;
       }
-      const path = `result${'.next'.repeat(65)}`;
+      const path = `result${'.next'.repeat(2049)}`;
 
       await expect(decodeValueAsync(value)).rejects.toMatchObject({
-        message: `Scientific envelope decode maximum depth 64 exceeded at ${path}`,
+        message: `Scientific envelope decode maximum depth 2048 exceeded at ${path}`,
       });
     });
 
     it('counts a torch tensor nested ndarray against the depth bound', async () => {
       const value: Record<string, unknown> = {};
       let cursor = value;
-      for (let depth = 0; depth < 63; depth += 1) {
+      for (let depth = 0; depth < 2047; depth += 1) {
         const next: Record<string, unknown> = {};
         cursor.next = next;
         cursor = next;
@@ -882,10 +931,11 @@ describe('Cross-Runtime Data Transfer Codec', () => {
         dtype: 'torch.int64',
         device: 'cpu',
       };
-      const path = `result${'.next'.repeat(63)}.tensor.value`;
+      const path = `result${'.next'.repeat(2047)}.tensor.value`;
+      const tensorPath = `result${'.next'.repeat(2047)}.tensor`;
 
       await expect(decodeValueAsync(value)).rejects.toMatchObject({
-        message: `Scientific envelope decode maximum depth 64 exceeded at ${path}`,
+        message: `Scientific envelope decode failed at ${tensorPath}: Scientific envelope decode maximum depth 2048 exceeded at ${path}`,
       });
     });
 
@@ -911,6 +961,36 @@ describe('Cross-Runtime Data Transfer Codec', () => {
       expect(nestedDecoded).toEqual({
         item: { __tywrap__: 'future.marker', value: ndarray([1]) },
       });
+    });
+
+    it('passes through frozen envelope-free objects and arrays unchanged', async () => {
+      const nested = Object.freeze({ value: 1 });
+      const items = Object.freeze([nested, 'plain']);
+      const value = Object.freeze({ items });
+
+      const decoded = await decodeValueAsync(value);
+      expect(decoded).toBe(value);
+      expect((decoded as { items: unknown }).items).toBe(items);
+    });
+
+    it('prefixes nested envelope validation errors with the traversal path', async () => {
+      const value = {
+        groups: [
+          {
+            matrix: {
+              __tywrap__: 'ndarray',
+              codecVersion: 1,
+              encoding: 'json',
+              data: [1],
+              dtype: 'int64',
+            },
+          },
+        ],
+      };
+
+      await expect(decodeValueAsync(value)).rejects.toThrow(
+        'Scientific envelope decode failed at result.groups[0].matrix: Invalid ndarray envelope: shape at path shape'
+      );
     });
 
     it('passes through custom-prototype objects without inspecting their contents', async () => {

--- a/test/runtime_codec.test.ts
+++ b/test/runtime_codec.test.ts
@@ -804,6 +804,134 @@ describe('Cross-Runtime Data Transfer Codec', () => {
     });
   });
 
+  describe('Recursive scientific envelope decoding', () => {
+    const ndarray = (data: unknown[], shape: number[] = [data.length]) => ({
+      __tywrap__: 'ndarray' as const,
+      codecVersion: 1,
+      encoding: 'json' as const,
+      data,
+      shape,
+      dtype: 'int64',
+    });
+
+    it('decodes envelopes in object, array, and deeply mixed containers', async () => {
+      const value = {
+        direct: ndarray([1, 2]),
+        items: ['plain', ndarray([3]), { nested: [ndarray([4, 5])] }],
+      };
+
+      await expect(decodeValueAsync(value)).resolves.toEqual({
+        direct: [1, 2],
+        items: ['plain', [3], { nested: [[4, 5]] }],
+      });
+    });
+
+    it('decodes an envelope inside a decoded container value', async () => {
+      const value = {
+        __tywrap__: 'dataframe' as const,
+        codecVersion: 1,
+        encoding: 'json' as const,
+        data: {
+          matrix: ndarray(
+            [
+              [1, 2],
+              [3, 4],
+            ],
+            [2, 2]
+          ),
+        },
+      };
+
+      await expect(decodeValueAsync(value)).resolves.toEqual({
+        matrix: [
+          [1, 2],
+          [3, 4],
+        ],
+      });
+    });
+
+    it('rejects values deeper than 64 with the exact path', async () => {
+      const value: Record<string, unknown> = {};
+      let cursor = value;
+      for (let depth = 0; depth < 65; depth += 1) {
+        const next: Record<string, unknown> = {};
+        cursor.next = next;
+        cursor = next;
+      }
+      const path = `result${'.next'.repeat(65)}`;
+
+      await expect(decodeValueAsync(value)).rejects.toMatchObject({
+        message: `Scientific envelope decode maximum depth 64 exceeded at ${path}`,
+      });
+    });
+
+    it('counts a torch tensor nested ndarray against the depth bound', async () => {
+      const value: Record<string, unknown> = {};
+      let cursor = value;
+      for (let depth = 0; depth < 63; depth += 1) {
+        const next: Record<string, unknown> = {};
+        cursor.next = next;
+        cursor = next;
+      }
+      cursor.tensor = {
+        __tywrap__: 'torch.tensor',
+        codecVersion: 1,
+        encoding: 'ndarray',
+        value: ndarray([1]),
+        shape: [1],
+        dtype: 'torch.int64',
+        device: 'cpu',
+      };
+      const path = `result${'.next'.repeat(63)}.tensor.value`;
+
+      await expect(decodeValueAsync(value)).rejects.toMatchObject({
+        message: `Scientific envelope decode maximum depth 64 exceeded at ${path}`,
+      });
+    });
+
+    it('rejects more than 1,000,000 visited nodes with the exact path', async () => {
+      const value = new Array<null>(1_000_000).fill(null);
+
+      await expect(decodeValueAsync(value)).rejects.toMatchObject({
+        message:
+          'Scientific envelope decode maximum visited nodes 1000000 exceeded at result[999999]',
+      });
+    });
+
+    it('preserves unknown nested marker behavior from the root', async () => {
+      const root = { __tywrap__: 'future.marker', value: ndarray([1]) };
+      const nested = { item: { __tywrap__: 'future.marker', value: ndarray([1]) } };
+      const nestedMarker = nested.item;
+
+      const rootDecoded = await decodeValueAsync(root);
+      const nestedDecoded = await decodeValueAsync(nested);
+      expect(rootDecoded).toBe(root);
+      expect(rootDecoded).toEqual({ __tywrap__: 'future.marker', value: ndarray([1]) });
+      expect((nestedDecoded as { item: unknown }).item).toBe(nestedMarker);
+      expect(nestedDecoded).toEqual({
+        item: { __tywrap__: 'future.marker', value: ndarray([1]) },
+      });
+    });
+
+    it('passes through custom-prototype objects without inspecting their contents', async () => {
+      const custom = Object.create({ kind: 'custom' }) as { value: unknown };
+      custom.value = ndarray([1]);
+
+      const customEnvelope = Object.assign(Object.create({ kind: 'custom' }), ndarray([3]));
+
+      const decoded = await decodeValueAsync({ custom, customEnvelope });
+      expect((decoded as { custom: unknown }).custom).toBe(custom);
+      expect(custom.value).toMatchObject({ __tywrap__: 'ndarray' });
+      expect((decoded as { customEnvelope: unknown }).customEnvelope).toBe(customEnvelope);
+
+      class CustomArray extends Array<unknown> {}
+      const customArray = new CustomArray(ndarray([2]));
+      const arrayDecoded = await decodeValueAsync({ customArray });
+      expect((arrayDecoded as { customArray: unknown }).customArray).toBe(customArray);
+      expect(customArray[0]).toMatchObject({ __tywrap__: 'ndarray' });
+    });
+  });
+
   describe('Encoding Edge Cases', () => {
     it('should handle missing encoding field', async () => {
       const envelope = {


### PR DESCRIPTION
## Summary

Fourth PR of the 0.10 codec correctness series, and the decoder half of nested composition. Dict/list returns containing scientific values no longer leak raw envelopes to callers.

- Async decoding recursively visits plain arrays and plain objects (Object/Array literals only; custom prototypes pass through) and decodes recognized envelopes at any depth.
- Envelope handler output is terminal: a decoded envelope's contents are never re-walked, so large payload data costs nothing extra and unknown-marker opacity is uniform at root and depth.
- Bounds: depth 2048 (above the Python producer's ~1000 recursion ceiling, so the decoder is never the binding constraint) and 1,000,000 container nodes — primitive leaves are free, since the payload byte cap already bounds them. Violations reject with JSONPath-style locations.
- Nested envelope failures carry their traversal path; root failures keep their existing message text.
- Sibling promise safety: a synchronous failure no longer leaves earlier async decodes as unhandled rejections. Unchanged values are never reassigned, so frozen envelope-free containers still pass through.
- The sync decode path (metadata/low-level consumers only; normal calls go async) now rejects recognized scientific envelopes with guidance instead of returning them raw.
- Value semantics documented: no alias identity across the bridge.

The Python producer still emits envelopes only at the root; the producer half (recursive serialization with cycle detection) is the next PR. Decoder-first ordering is deliberate — the bundled bridge means a nesting-aware decoder before a nesting producer is strictly safe.

## Review

Built by codex sol; independent sol xhigh review found 6 defects (handler-output walking that ate the node budget on 1M-element arrays, unhandled sibling rejections, frozen-object regression, lost nested error paths, opacity inconsistency, depth bound too tight) — all fixed and re-verified, plus a coordinator-caught fix making the node budget container-only.

## Verification

- Menagerie: 90/90 against pinned scientific libs (deeply-nested row restored to honest)
- `npm run check:all`: 1,368 passed; GC/perf-budget suite green