### PR TITLE
docs: agent-first adoption guide + maintainer docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,8 @@
 ## Project Overview
 
 tywrap generates type-safe TypeScript wrappers for Python libraries. It has two components:
-- **`tywrap`** (npm) — TypeScript/Node.js/Bun/Deno runtime bridges and CLI code generator
-- **`tywrap-ir`** (PyPI) — Python AST analyzer that extracts typed IR from Python source
+- **`tywrap`** (npm) provides TypeScript/Node.js/Bun/Deno runtime bridges and a CLI code generator
+- **`tywrap-ir`** (PyPI) provides a Python AST analyzer that extracts typed IR from Python source
 
 The generated wrappers let you call Python functions from TypeScript with full type safety,
 using either a subprocess bridge (Node/Bun/Deno), in-browser WebAssembly (Pyodide), or HTTP.
@@ -95,10 +95,10 @@ dist/                 # Compiled TypeScript output (do not edit)
 
 ## Code Conventions
 
-- TypeScript strict mode; avoid `any` — use `unknown` and type guards instead
+- TypeScript strict mode; avoid `any`; use `unknown` and type guards instead
 - Runtime bridges: `src/runtime/`; corresponding tests: `test/runtime_*.test.ts`
 - Python code: `tywrap_ir/`; follow PEP 8, use type hints
-- Generated files (`generated/`, `dist/`) — never edit manually
+- Generated files (`generated/`, `dist/`): never edit manually
 - `TYWRAP_PERF_BUDGETS=1` enables performance budget assertions in tests
 - `NODE_OPTIONS=--expose-gc` required for GC-sensitive tests
 
@@ -114,7 +114,7 @@ Conventional commits with scope:
 ## PR Guidelines
 
 1. Include tests for new runtime behavior (see `test/runtime_*.test.ts` patterns)
-2. Run `npm run check:all` before pushing — this runs format, lint, build, type tests, and unit tests
+2. Run `npm run check:all` before pushing; this runs format, lint, build, type tests, and unit tests
 3. Wait for CI to be green including the `required` job
 4. Resolve all CodeRabbit review threads before merging
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,8 @@
 ## Project Overview
 
 tywrap generates type-safe TypeScript wrappers for Python libraries. It has two components:
-- **`tywrap`** (npm) — TypeScript/Node.js/Bun/Deno runtime bridges and CLI code generator
-- **`tywrap-ir`** (PyPI) — Python AST analyzer that extracts typed IR from Python source
+- **`tywrap`** (npm) provides TypeScript/Node.js/Bun/Deno runtime bridges and a CLI code generator
+- **`tywrap-ir`** (PyPI) provides a Python AST analyzer that extracts typed IR from Python source
 
 The generated wrappers let you call Python functions from TypeScript with full type safety,
 using either a subprocess bridge (Node/Bun/Deno), in-browser WebAssembly (Pyodide), or HTTP.
@@ -95,10 +95,10 @@ dist/                 # Compiled TypeScript output (do not edit)
 
 ## Code Conventions
 
-- TypeScript strict mode; avoid `any` — use `unknown` and type guards instead
+- TypeScript strict mode; avoid `any`; use `unknown` and type guards instead
 - Runtime bridges: `src/runtime/`; corresponding tests: `test/runtime_*.test.ts`
 - Python code: `tywrap_ir/`; follow PEP 8, use type hints
-- Generated files (`generated/`, `dist/`) — never edit manually
+- Generated files (`generated/`, `dist/`): never edit manually
 - `TYWRAP_PERF_BUDGETS=1` enables performance budget assertions in tests
 - `NODE_OPTIONS=--expose-gc` required for GC-sensitive tests
 
@@ -114,7 +114,7 @@ Conventional commits with scope:
 ## PR Guidelines
 
 1. Include tests for new runtime behavior (see `test/runtime_*.test.ts` patterns)
-2. Run `npm run check:all` before pushing — this runs format, lint, build, type tests, and unit tests
+2. Run `npm run check:all` before pushing; this runs format, lint, build, type tests, and unit tests
 3. Wait for CI to be green including the `required` job
 4. Resolve all CodeRabbit review threads before merging
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,20 +1,114 @@
 # Contributing to tywrap
 
-Thanks for your interest in contributing!
+This guide is the maintainer entry point. Read the [release guide](docs/release.md)
+before changing package versions, IR versions, or generated release artifacts.
 
-- Development setup:
-  - Node 20+ and Python 3.10+ (CI tests 3.10, 3.11, 3.12)
-  - npm ci
-  - npm run check:all
-- Common tasks:
-  - Build: npm run build
-  - Lint: npm run lint (fix: npm run lint:fix)
-  - Tests: npm test (types: npm run test:types)
-- Commit:
-  - Use clear, conventional messages (feat, fix, chore, docs, refactor, test)
-- Pull Requests:
-  - Include tests and type definitions where applicable
-  - Ensure `npm run check:all` passes
-  - Wait for CI to be green (including `CI/required`) and for CodeRabbit to complete; resolve all review threads
+## Setup
 
-By contributing, you agree to license your contributions under the project’s MIT License.
+Use Node.js 20 or later and Python 3.10 or later. CI covers Python 3.10, 3.11,
+and 3.12. The main lint job uses Node 22 and Python 3.11.
+
+```bash
+npm ci
+pip install -e tywrap_ir/
+```
+
+Run the normal gate after a focused change:
+
+```bash
+npm run check:all
+```
+
+`check:all` runs format checking, linting, the build, type tests, and unit
+tests. It does not replace the focused test command for a changed subsystem.
+
+## Test map
+
+| Surface | Command | What it checks |
+| --- | --- | --- |
+| TypeScript unit and runtime tests | `npm test` | Generator, transports, codec, and bridge behavior. |
+| Type-level tests | `npm run test:types` | Generated and exported TypeScript types through `test-d/`. |
+| Python producer tests | `python -m pytest test/python/test_bridge_codec.py test/python/test_frame_codec.py` | Python codec and frame behavior. |
+| Core Python library suite | `npm run test:python:suite:core` | IR extraction against core libraries. |
+| Data Python library suite | `npm run test:python:suite:data` | IR extraction against data libraries. |
+| Menagerie | `npm run test:menagerie` | Named generation and runtime codec truth-table rows. |
+
+Set `TYWRAP_PERF_BUDGETS=1` to enable performance budget assertions. Set
+`NODE_OPTIONS=--expose-gc` for GC-sensitive memory tests. CI sets both in its
+main test jobs.
+
+## Menagerie
+
+`test/menagerie/manifest.ts` is the executable catalogue. Each row is one
+Python call under one codec configuration.
+
+| Status | Meaning |
+| --- | --- |
+| `EXPECTED_OK` | The stated value survives. |
+| `KNOWN_LIE` | The call resolves with a documented loss and expected future fix. |
+| `LOUD_FAIL` | The call rejects with a checked error. |
+
+A behavior change must flip its menagerie rows in the same PR. Add a row
+when a new representation or failure domain becomes observable. Do not relabel
+a known loss as supported without an executable expectation.
+
+The `optional-scientific-menagerie` CI job uses pinned Python 3.11 packages:
+NumPy 2.3.5, pandas 3.0.2, pyarrow 24.0.0, SciPy 1.16.3,
+scikit-learn 1.8.0, and CPU-only torch 2.10.0. Use the same pins locally when
+investigating a scientific row:
+
+```bash
+python3.11 -m venv .venv-menagerie
+.venv-menagerie/bin/python -m pip install -e tywrap_ir
+.venv-menagerie/bin/python -m pip install numpy==2.3.5 pandas==3.0.2 pyarrow==24.0.0 scipy==1.16.3 scikit-learn==1.8.0
+.venv-menagerie/bin/python -m pip install torch==2.10.0 --index-url https://download.pytorch.org/whl/cpu
+TYWRAP_CODEC_PYTHON=.venv-menagerie/bin/python npm run test:menagerie
+```
+
+See [Menagerie Discipline](docs/maintainers/menagerie.md) for row structure
+and status obligations.
+
+## Generated files
+
+Never hand-edit `src/runtime/pyodide-bootstrap-core.generated.ts` or
+`docs/public/llms-full.txt`. Regenerate the Pyodide bootstrap with its script
+after changing `runtime/tywrap_bridge_core.py`. Regenerate the full LLM bundle
+with:
+
+```bash
+node scripts/generate-llms-full.mjs
+```
+
+Generated wrappers and `<module>.contract.json` files belong to the consuming
+project. Use `npx tywrap generate --check` to detect their drift.
+
+## Documentation
+
+VitePress content lives under `docs/`. Build the site with:
+
+```bash
+npm run docs:build
+```
+
+The build synchronizes `llms-full.txt`; run the generator again as the final
+documentation step when its source pages changed. Keep `docs/public/llms.txt`
+as the hand-maintained index. Before committing prose, run:
+
+```bash
+~/.claude/skills/write-like-a-human/scripts/sloplint.sh <changed-markdown-files>
+```
+
+Fix each pattern hit. Reference-page metric warnings are advisory.
+
+## Pull requests
+
+Use conventional commits such as `fix(codec): reject invalid envelope` or
+`docs: update agent adoption guide`. Include tests for behavior changes and
+type tests when the public TypeScript surface changes.
+
+Run `npm run check:all` once before pushing. CI must pass, including the
+`required` job. Wait for CodeRabbit and resolve every review thread before
+merging.
+
+By contributing, you agree to license your contributions under the project’s
+MIT License.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ For CI (or to verify a dependency upgrade didn’t change the generated surface)
 npx tywrap generate --check
 ```
 
+## For coding agents
+
+Start with the [agent adoption guide](https://bbopen.github.io/tywrap/guide/agent-adoption)
+for exact commands, expected output, and failure fixes. The structured
+[llms.txt](https://bbopen.github.io/tywrap/llms.txt) index links to the same
+agent-facing docs and the supporting reference pages.
+
 For local Node development, `tywrap/dev` watches local Python package trees and
 regenerates wrappers. It swaps the active bridge only after a successful
 generation, so a failed regeneration leaves the previous state in place.
@@ -182,13 +189,11 @@ import { defineConfig } from 'tywrap';
 export default defineConfig({
   pythonModules: {
     pandas: {
-      runtime: 'node',
       typeHints: 'strict',
       classes: ['DataFrame'],
       functions: ['read_csv'],
     },
     numpy: {
-      runtime: 'node',
       typeHints: 'strict',
       alias: 'np',
     },

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
         text: 'Guide',
         items: [
           { text: 'Getting Started', link: '/guide/getting-started' },
+          { text: 'Agent Adoption', link: '/guide/agent-adoption' },
           { text: 'Configuration', link: '/guide/configuration' },
           { text: 'Watch & Reload', link: '/guide/dev-reload' },
           {
@@ -51,6 +52,13 @@ export default defineConfig({
           { text: 'Type Mapping', link: '/reference/type-mapping' },
           { text: 'Scientific Codec Envelopes', link: '/codec-envelopes' },
           { text: 'API', link: '/reference/api/' },
+        ],
+      },
+      {
+        text: 'Maintainers',
+        items: [
+          { text: 'Architecture', link: '/maintainers/architecture' },
+          { text: 'Menagerie Discipline', link: '/maintainers/menagerie' },
         ],
       },
       {

--- a/docs/guide/agent-adoption.md
+++ b/docs/guide/agent-adoption.md
@@ -1,0 +1,131 @@
+# Agent Adoption
+
+Use `NodeBridge` for a TypeScript project that can start a local Python
+process. Use `PyodideBridge` for browser code. Use `HttpBridge` when Python
+runs on another host. See the [runtime comparison](./runtimes/comparison) for
+constraints such as Deno Deploy and Arrow support.
+
+## Recipe
+
+Run these commands from the TypeScript project root. Replace `math` with the
+Python module the project must call.
+
+```bash
+npm install tywrap
+```
+
+Expected output includes an added `tywrap` dependency in `package.json`.
+
+```bash
+pip install tywrap-ir
+```
+
+Expected output ends with a successful `tywrap-ir` installation. This `pip`
+must install into the same Python environment configured below.
+
+```bash
+npx tywrap init
+```
+
+Expected output:
+
+```text
+Created /absolute/path/to/project/tywrap.config.ts
+```
+
+The command writes this starter configuration and adds `tywrap:generate` and
+`tywrap:check` scripts when `package.json` exists:
+
+```ts
+import { defineConfig } from 'tywrap';
+
+export default defineConfig({
+  pythonModules: {
+    math: { typeHints: 'strict' },
+  },
+  output: {
+    dir: './generated',
+    format: 'esm',
+    declaration: false,
+    sourceMap: false,
+  },
+  runtime: {
+    node: {
+      pythonPath: 'python3',
+    },
+  },
+  types: {
+    presets: ['stdlib'],
+  },
+});
+```
+
+Edit `pythonModules` and `runtime.node.pythonPath` as needed. A local module
+also needs its parent directory in `pythonImportPath`.
+
+```bash
+npx tywrap generate
+```
+
+Expected output for one module:
+
+```text
+Generated: 2 files from 1 modules (warnings: 0).
+- generated/math.generated.ts
+- generated/math.contract.json
+```
+
+The wrapper is `<module>.generated.ts`. The pinned extractor output is
+`<module>.contract.json`. Import the compiled wrapper, set the bridge once,
+then call the wrapper:
+
+```ts
+import { NodeBridge } from 'tywrap/node';
+import { setRuntimeBridge } from 'tywrap/runtime';
+import * as math from './generated/math.generated.js';
+
+setRuntimeBridge(new NodeBridge({ pythonPath: 'python3' }));
+
+const value = await math.sqrt(16);
+console.log(value); // 4
+```
+
+Expected output:
+
+```text
+4
+```
+
+## Verify generated output
+
+Commit the wrapper and contract files, then check them in CI:
+
+```bash
+npx tywrap generate --check
+```
+
+Expected output when current:
+
+```text
+Generated wrappers are up to date.
+```
+
+Exit code `0` means all generated files match. Exit code `1` means generation
+failed, including a missing configuration or Python import failure. Exit code
+`2` means `--fail-on-warn` found warnings. Exit code `3` means generated files
+or contracts differ; run `npx tywrap generate` and commit the result. See the
+[CLI reference](/reference/cli) for the complete command surface.
+
+## Failure signatures
+
+| Error prefix or text | Fix |
+| --- | --- |
+| `IR extraction failed` or `ModuleNotFoundError` | Install the target Python module in the same interpreter named by `runtime.node.pythonPath`. For a local module, add its parent directory to `pythonImportPath`. |
+| `No IR produced for module` or `tywrap_ir failed.` | Run `pip install tywrap-ir` in that configured Python environment, then rerun generation. |
+| `IR version mismatch:` or `ir-version-mismatch` | Upgrade `tywrap-ir` to match `tywrap`, then regenerate the contract. |
+| `contract-invalid` or `Contract ... is missing` | Replace the invalid or stale `contractInput` with a regenerated contract. |
+| `Generated wrappers are out of date:` | Run `npx tywrap generate`, review the wrapper and contract changes, and commit them. |
+| `Received an Arrow-encoded payload but no Arrow decoder is available.` | Run `npm install apache-arrow`, or set `TYWRAP_CODEC_FALLBACK=json` on the Python side when its documented JSON domain is acceptable. |
+| `JSON pandas.DataFrame encoding requires an unnamed RangeIndex` or `JSON pandas.Series encoding requires an unnamed RangeIndex` | Follow the recipe in the error, such as `.reset_index(drop=True)`, or use Arrow. Other JSON codec preflight errors also state their conversion recipe. Apply that recipe rather than suppressing the error. |
+| `Return validation failed for` (`BridgeValidationError`) | Compare the Python return value with the generated declared type. The message gives the call site and describes the expected type and received shape. Fix the annotation or returned value, then regenerate. |
+| `Response payload is ... exceeds TYWRAP_CODEC_MAX_BYTES=` | Raise `TYWRAP_CODEC_MAX_BYTES` only for a response size the process can handle, or return a smaller result. |

--- a/docs/guide/agent-adoption.md
+++ b/docs/guide/agent-adoption.md
@@ -41,22 +41,22 @@ import { defineConfig } from 'tywrap';
 
 export default defineConfig({
   pythonModules: {
-    math: { typeHints: 'strict' },
+    "math": { typeHints: 'strict' },
   },
   output: {
     dir: './generated',
     format: 'esm',
     declaration: false,
-    sourceMap: false,
+    sourceMap: false
   },
   runtime: {
     node: {
-      pythonPath: 'python3',
-    },
+      pythonPath: 'python3'
+    }
   },
   types: {
-    presets: ['stdlib'],
-  },
+    presets: ['stdlib']
+  }
 });
 ```
 
@@ -70,10 +70,14 @@ npx tywrap generate
 Expected output for one module:
 
 ```text
-Generated: 2 files from 1 modules (warnings: 0).
+Generated: 2 files from 1 modules (warnings: 1).
 - generated/math.generated.ts
 - generated/math.contract.json
 ```
+
+A nonzero warning count is normal for C modules such as `math`: functions
+without Python return annotations degrade to `unknown` and the warning names
+them. Generation still succeeds.
 
 The wrapper is `<module>.generated.ts`. The pinned extractor output is
 `<module>.contract.json`. Import the compiled wrapper, set the bridge once,

--- a/docs/guide/agent-adoption.md
+++ b/docs/guide/agent-adoption.md
@@ -120,8 +120,8 @@ or contracts differ; run `npx tywrap generate` and commit the result. See the
 
 | Error prefix or text | Fix |
 | --- | --- |
-| `IR extraction failed` or `ModuleNotFoundError` | Install the target Python module in the same interpreter named by `runtime.node.pythonPath`. For a local module, add its parent directory to `pythonImportPath`. |
-| `No IR produced for module` or `tywrap_ir failed.` | Run `pip install tywrap-ir` in that configured Python environment, then rerun generation. |
+| `No IR produced for module ... tywrap_ir failed.` with `ModuleNotFoundError` | Install the target Python module in the same interpreter named by `runtime.node.pythonPath`. For a local module, add its parent directory to `pythonImportPath`. |
+| `No IR produced for module` or `tywrap_ir not found on PYTHONPATH.` | Run `pip install tywrap-ir` in that configured Python environment, then rerun generation. |
 | `IR version mismatch:` or `ir-version-mismatch` | Upgrade `tywrap-ir` to match `tywrap`, then regenerate the contract. |
 | `contract-invalid` or `Contract ... is missing` | Replace the invalid or stale `contractInput` with a regenerated contract. |
 | `Generated wrappers are out of date:` | Run `npx tywrap generate`, review the wrapper and contract changes, and commit them. |

--- a/docs/maintainers/architecture.md
+++ b/docs/maintainers/architecture.md
@@ -40,8 +40,8 @@ promise resolves.
 
 `NodeBridge` starts `runtime/python_bridge.py` through the subprocess transport.
 Normal requests and responses are JSONL. When a request or response crosses the
-line ceiling, `src/runtime/frame-codec.ts` splits it into negotiated
-`tywrap-frame/1` frames. Reassembly remains bounded by the codec payload limit.
+line ceiling, `src/runtime/frame-codec.ts` splits it into `tywrap-frame/1`
+frames. Reassembly remains bounded by the codec payload limit.
 
 `PyodideBridge` runs the shared Python bridge core in WebAssembly. Its generated
 bootstrap source lives in `src/runtime/pyodide-bootstrap-core.generated.ts`; do

--- a/docs/maintainers/architecture.md
+++ b/docs/maintainers/architecture.md
@@ -12,7 +12,7 @@ the declared return schema.
 | Python analysis | `tywrap_ir/tywrap_ir/__main__.py`, `tywrap_ir/tywrap_ir/` | The extractor emits JSON typed IR for the requested module. |
 | IR contract | `src/tywrap.ts`, `src/types/` | A contract has the expected module and `ir_version`. The current version is `0.4.0`. |
 | Wrapper generation | `src/core/generator.ts`, `src/core/emit-call.ts`, `src/core/mapper.ts` | Generated calls carry a `ReturnSchema` that represents the Python return annotation. |
-| Runtime transport | `src/runtime/node.ts`, `src/runtime/subprocess-transport.ts`, `src/runtime/frame-codec.ts`, `runtime/python_bridge.py` | Node subprocess requests use JSONL and negotiate `tywrap-frame/1` when a message exceeds one line. |
+| Runtime transport | `src/runtime/node.ts`, `src/runtime/subprocess-transport.ts`, `src/runtime/frame-codec.ts`, `runtime/python_bridge.py` | Node subprocess requests use JSONL and use `tywrap-frame/1` when a message exceeds one line. |
 | Python dispatch and encoding | `runtime/tywrap_bridge_core.py`, `runtime/safe_codec.py` | The bridge validates protocol input, then dispatches the requested call and returns JSON-safe values or versioned envelopes. |
 | JavaScript decoding | `src/utils/codec.ts`, `src/runtime/bridge-codec.ts` | Envelope shape and payload domains are checked before a decoded value reaches application code. |
 | Return validation | `src/runtime/validators.ts` | A decoded result matches the generated `ReturnSchema`, including scientific provenance when declared. |

--- a/docs/maintainers/architecture.md
+++ b/docs/maintainers/architecture.md
@@ -1,0 +1,102 @@
+# Architecture
+
+tywrap has a generation pipeline and a runtime pipeline. The generation
+pipeline turns Python declarations into TypeScript wrappers. The runtime
+pipeline executes a generated call and returns a decoded result that must match
+the declared return schema.
+
+## Pipeline
+
+| Stage | Owners | Invariant |
+| --- | --- | --- |
+| Python analysis | `tywrap_ir/tywrap_ir/__main__.py`, `tywrap_ir/tywrap_ir/` | The extractor emits JSON typed IR for the requested module. |
+| IR contract | `src/tywrap.ts`, `src/types/` | A contract has the expected module and `ir_version`. The current version is `0.4.0`. |
+| Wrapper generation | `src/core/generator.ts`, `src/core/emit-call.ts`, `src/core/mapper.ts` | Generated calls carry a `ReturnSchema` that represents the Python return annotation. |
+| Runtime transport | `src/runtime/node.ts`, `src/runtime/subprocess-transport.ts`, `src/runtime/frame-codec.ts`, `runtime/python_bridge.py` | Node subprocess requests use JSONL and negotiate `tywrap-frame/1` when a message exceeds one line. |
+| Python dispatch and encoding | `runtime/tywrap_bridge_core.py`, `runtime/safe_codec.py` | The bridge validates protocol input, then dispatches the requested call and returns JSON-safe values or versioned envelopes. |
+| JavaScript decoding | `src/utils/codec.ts`, `src/runtime/bridge-codec.ts` | Envelope shape and payload domains are checked before a decoded value reaches application code. |
+| Return validation | `src/runtime/validators.ts` | A decoded result matches the generated `ReturnSchema`, including scientific provenance when declared. |
+
+## IR and generated contracts
+
+`generate()` in `src/tywrap.ts` invokes `python -m tywrap_ir --module <name>`.
+It validates the returned object before passing it to `CodeGenerator`. The
+generator writes `<module>.generated.ts` and the stable
+`<module>.contract.json` file beside it. The contract omits extractor metadata,
+sorts object keys, and records the pinned IR representation.
+
+`contractInput` changes the source of IR. Instead of starting Python, generation
+reads a saved contract and applies the same module and version validation. This
+supports reproducible generation. A version mismatch is a hard failure: update
+the matching package pair and regenerate the contract.
+
+`src/core/generator.ts` maps annotations to TypeScript and emits one
+`createReturnValidator()` call per generated callable. Return schemas cover
+primitive values, containers, definitions, and scientific markers. The
+wrapper calls the active bridge and validates the resolved value before its
+promise resolves.
+
+## Runtime bridges
+
+`NodeBridge` starts `runtime/python_bridge.py` through the subprocess transport.
+Normal requests and responses are JSONL. When a request or response crosses the
+line ceiling, `src/runtime/frame-codec.ts` splits it into negotiated
+`tywrap-frame/1` frames. Reassembly remains bounded by the codec payload limit.
+
+`PyodideBridge` runs the shared Python bridge core in WebAssembly. Its generated
+bootstrap source lives in `src/runtime/pyodide-bootstrap-core.generated.ts`; do
+not edit it directly. Regenerate it from `runtime/tywrap_bridge_core.py` with
+the repository script. Pyodide uses JSON codec envelopes because pyarrow is not
+available in WASM.
+
+`HttpBridge` sends the same RPC and codec concepts to a remote Python service.
+The transport owns HTTP concerns while the codec and return validator preserve
+the client-side invariants.
+
+## Codec envelopes
+
+`runtime/tywrap_bridge_core.py` recognizes scientific values and replaces them
+with envelopes marked by `__tywrap__`, `codecVersion: 1`, and an `encoding`.
+The marker set is `ndarray`, `dataframe`, `series`, `scipy.sparse`,
+`torch.tensor`, and `sklearn.estimator`. `src/utils/codec.ts` is the matching
+decoder and validates each envelope before decoding it.
+
+Arrow is the default for scientific arrays and pandas tabular values when
+Python has pyarrow and JavaScript has an Arrow decoder. JSON fallback is
+explicit through `TYWRAP_CODEC_FALLBACK=json`; it has narrower, documented
+domains. Pandas JSON values require an unnamed zero-based
+`RangeIndex`, and unsupported dtypes fail with a conversion recipe.
+
+Nested arrays and plain objects can contain envelopes. The producer permits a
+depth of 900 and at most 1,000,000 visited containers. The decoder permits a
+depth of 2048 and the same container count. The budget excludes primitive
+leaves. A decoded envelope is terminal, except for
+the required nested ndarray inside a torch envelope.
+
+## Runtime return validation
+
+`src/runtime/validators.ts` validates the value after decoding. A mismatch
+throws `BridgeValidationError` with the call site, declared type, and received
+shape. Scientific values retain non-enumerable provenance from their envelope.
+The validator checks the marker and, when the schema declares them, dimensions
+and dtype without walking Arrow payload data. `unknown`, `void`, and `Any`
+returns deliberately receive no runtime check.
+
+## One call end to end
+
+1. A generated call such as `math.sqrt(16)` builds a bridge request and its
+   generated `ReturnSchema` validator.
+2. `NodeBridge` sends the request over JSONL, or `tywrap-frame/1` frames when
+   it is too large for one line.
+3. `runtime/python_bridge.py` reads the request and calls
+   `dispatch_request()` in `runtime/tywrap_bridge_core.py`.
+4. The core imports the requested module, dispatches `sqrt`, and serializes its
+   result. A scientific result becomes a version-1 envelope; a plain number
+   remains JSON.
+5. The subprocess transport returns the response. `BridgeCodec` and
+   `decodeEnvelopeAsync()` validate and decode its value.
+6. The generated return validator accepts the decoded number and resolves the
+   promise. A mismatched value throws `BridgeValidationError` instead.
+
+Read [Scientific Codec Envelopes](/codec-envelopes) before changing an
+envelope. It defines the supported JSON domains and validation behavior.

--- a/docs/maintainers/architecture.md
+++ b/docs/maintainers/architecture.md
@@ -20,9 +20,9 @@ the declared return schema.
 ## IR and generated contracts
 
 `generate()` in `src/tywrap.ts` invokes `python -m tywrap_ir --module <name>`.
-It validates the returned object before passing it to `CodeGenerator`. The
-generator writes `<module>.generated.ts` and the stable
-`<module>.contract.json` file beside it. The contract omits extractor metadata,
+It validates the returned object before passing it to `CodeGenerator`, which
+produces the wrapper source; `src/tywrap.ts` then writes
+`<module>.generated.ts` and the stable `<module>.contract.json` beside it. The contract omits extractor metadata,
 sorts object keys, and records the pinned IR representation.
 
 `contractInput` changes the source of IR. Instead of starting Python, generation
@@ -61,10 +61,11 @@ The marker set is `ndarray`, `dataframe`, `series`, `scipy.sparse`,
 `torch.tensor`, and `sklearn.estimator`. `src/utils/codec.ts` is the matching
 decoder and validates each envelope before decoding it.
 
-Arrow is the default for scientific arrays and pandas tabular values when
-Python has pyarrow and JavaScript has an Arrow decoder. JSON fallback is
-explicit through `TYWRAP_CODEC_FALLBACK=json`; it has narrower, documented
-domains. Pandas JSON values require an unnamed zero-based
+The Python producer selects Arrow for scientific arrays and pandas tabular
+values whenever pyarrow is importable, and the JavaScript side never falls
+back on its own: an Arrow envelope arriving without an Arrow decoder throws
+with an installation hint. Choosing JSON is an explicit Python-side decision
+through `TYWRAP_CODEC_FALLBACK=json`, with narrower, documented domains. Pandas JSON values require an unnamed zero-based
 `RangeIndex`, and unsupported dtypes fail with a conversion recipe.
 
 Nested arrays and plain objects can contain envelopes. The producer permits a

--- a/docs/maintainers/menagerie.md
+++ b/docs/maintainers/menagerie.md
@@ -19,7 +19,7 @@ Optional-library tests add cases that require installed scientific packages.
 | Status | Meaning | Obligation |
 | --- | --- | --- |
 | `EXPECTED_OK` | The call preserves the stated result. | Assert the exact value or declared structural expectation. |
-| `KNOWN_LIE` | The current transport resolves but loses stated semantics. | Record the observed result and an `expectedFix`. Do not describe the behavior as lossless. |
+| `KNOWN_LIE` | The current transport resolves but loses stated semantics. | Record the observed result, and an `expectedFix` when a fix direction exists. Do not describe the behavior as lossless. |
 | `LOUD_FAIL` | The call must reject at the bridge boundary. | Supply an error expectation. The test checks that error rows and this status stay aligned. |
 
 `KNOWN_LIE` is documentation of a measured limitation, not a passing result to

--- a/docs/maintainers/menagerie.md
+++ b/docs/maintainers/menagerie.md
@@ -1,0 +1,63 @@
+# Menagerie Discipline
+
+The menagerie is the executable truth table for generation and codec behavior.
+Its catalogue is `test/menagerie/manifest.ts`. It contains rows rather
+than a claim that a broad type family works.
+
+## A row
+
+A runtime catalogue row describes one Python call under one codec path. It has
+an `id`, fixture, call, expected result or error, status, and optional package
+requirements. A row can select Arrow or JSON fallback. The test runs the call
+through `NodeBridge`. It does not test a serializer in isolation.
+
+The generation gate also generates and typechecks the tier-one fixture modules.
+Optional-library tests add cases that require installed scientific packages.
+
+## Statuses
+
+| Status | Meaning | Obligation |
+| --- | --- | --- |
+| `EXPECTED_OK` | The call preserves the stated result. | Assert the exact value or declared structural expectation. |
+| `KNOWN_LIE` | The current transport resolves but loses stated semantics. | Record the observed result and an `expectedFix`. Do not describe the behavior as lossless. |
+| `LOUD_FAIL` | The call must reject at the bridge boundary. | Supply an error expectation. The test checks that error rows and this status stay aligned. |
+
+`KNOWN_LIE` is documentation of a measured limitation, not a passing result to
+silently improve. `LOUD_FAIL` is a contract that a value outside the supported
+domain fails with an error that states the cause.
+
+## Add or change a row
+
+1. Add the fixture function in `test/menagerie/fixtures/` when needed.
+2. Add one catalogue row in `test/menagerie/manifest.ts` with the codec,
+   status, current behavior, and expectation.
+3. Declare every optional library in `requires` and any feature condition in
+   `featureProbe`.
+4. Run `npm run test:menagerie` with the pinned dependencies below.
+5. Update generated snapshots when the generation gate intentionally changes.
+
+When behavior changes, flip the rows in the same PR. A fix that turns a
+lossy result into a preserved result changes `KNOWN_LIE` to `EXPECTED_OK`; a
+newly supported representation needs its own row. Do not leave the
+catalogue describing yesterday's behavior.
+
+## Pinned scientific job
+
+GitHub Actions runs `optional-scientific-menagerie` on Python 3.11 and Node 22.
+It installs `tywrap_ir`, then pins NumPy 2.3.5, pandas 3.0.2, pyarrow 24.0.0,
+SciPy 1.16.3, scikit-learn 1.8.0, and CPU-only torch 2.10.0. The pins make a
+truth-table change reviewable rather than a moving dependency result.
+
+Run the same gate locally in a fresh virtual environment:
+
+```bash
+python3.11 -m venv .venv-menagerie
+.venv-menagerie/bin/python -m pip install -e tywrap_ir
+.venv-menagerie/bin/python -m pip install numpy==2.3.5 pandas==3.0.2 pyarrow==24.0.0 scipy==1.16.3 scikit-learn==1.8.0
+.venv-menagerie/bin/python -m pip install torch==2.10.0 --index-url https://download.pytorch.org/whl/cpu
+TYWRAP_CODEC_PYTHON=.venv-menagerie/bin/python npm run test:menagerie
+```
+
+The test skips a row only when its declared optional dependency or feature
+probe is unavailable. The pinned CI job provides the expected scientific
+surface for review.

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -501,22 +501,22 @@ import { defineConfig } from 'tywrap';
 
 export default defineConfig({
   pythonModules: {
-    math: { typeHints: 'strict' },
+    "math": { typeHints: 'strict' },
   },
   output: {
     dir: './generated',
     format: 'esm',
     declaration: false,
-    sourceMap: false,
+    sourceMap: false
   },
   runtime: {
     node: {
-      pythonPath: 'python3',
-    },
+      pythonPath: 'python3'
+    }
   },
   types: {
-    presets: ['stdlib'],
-  },
+    presets: ['stdlib']
+  }
 });
 ```
 
@@ -530,10 +530,14 @@ npx tywrap generate
 Expected output for one module:
 
 ```text
-Generated: 2 files from 1 modules (warnings: 0).
+Generated: 2 files from 1 modules (warnings: 1).
 - generated/math.generated.ts
 - generated/math.contract.json
 ```
+
+A nonzero warning count is normal for C modules such as `math`: functions
+without Python return annotations degrade to `unknown` and the warning names
+them. Generation still succeeds.
 
 The wrapper is `<module>.generated.ts`. The pinned extractor output is
 `<module>.contract.json`. Import the compiled wrapper, set the bridge once,
@@ -3338,9 +3342,9 @@ the declared return schema.
 ## IR and generated contracts
 
 `generate()` in `src/tywrap.ts` invokes `python -m tywrap_ir --module <name>`.
-It validates the returned object before passing it to `CodeGenerator`. The
-generator writes `<module>.generated.ts` and the stable
-`<module>.contract.json` file beside it. The contract omits extractor metadata,
+It validates the returned object before passing it to `CodeGenerator`, which
+produces the wrapper source; `src/tywrap.ts` then writes
+`<module>.generated.ts` and the stable `<module>.contract.json` beside it. The contract omits extractor metadata,
 sorts object keys, and records the pinned IR representation.
 
 `contractInput` changes the source of IR. Instead of starting Python, generation
@@ -3379,10 +3383,11 @@ The marker set is `ndarray`, `dataframe`, `series`, `scipy.sparse`,
 `torch.tensor`, and `sklearn.estimator`. `src/utils/codec.ts` is the matching
 decoder and validates each envelope before decoding it.
 
-Arrow is the default for scientific arrays and pandas tabular values when
-Python has pyarrow and JavaScript has an Arrow decoder. JSON fallback is
-explicit through `TYWRAP_CODEC_FALLBACK=json`; it has narrower, documented
-domains. Pandas JSON values require an unnamed zero-based
+The Python producer selects Arrow for scientific arrays and pandas tabular
+values whenever pyarrow is importable, and the JavaScript side never falls
+back on its own: an Arrow envelope arriving without an Arrow decoder throws
+with an installation hint. Choosing JSON is an explicit Python-side decision
+through `TYWRAP_CODEC_FALLBACK=json`, with narrower, documented domains. Pandas JSON values require an unnamed zero-based
 `RangeIndex`, and unsupported dtypes fail with a conversion recipe.
 
 Nested arrays and plain objects can contain envelopes. The producer permits a
@@ -3443,7 +3448,7 @@ Optional-library tests add cases that require installed scientific packages.
 | Status | Meaning | Obligation |
 | --- | --- | --- |
 | `EXPECTED_OK` | The call preserves the stated result. | Assert the exact value or declared structural expectation. |
-| `KNOWN_LIE` | The current transport resolves but loses stated semantics. | Record the observed result and an `expectedFix`. Do not describe the behavior as lossless. |
+| `KNOWN_LIE` | The current transport resolves but loses stated semantics. | Record the observed result, and an `expectedFix` when a fix direction exists. Do not describe the behavior as lossless. |
 | `LOUD_FAIL` | The call must reject at the bridge boundary. | Supply an error expectation. The test checks that error rows and this status stay aligned. |
 
 `KNOWN_LIE` is documentation of a measured limitation, not a passing result to

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -580,8 +580,8 @@ or contracts differ; run `npx tywrap generate` and commit the result. See the
 
 | Error prefix or text | Fix |
 | --- | --- |
-| `IR extraction failed` or `ModuleNotFoundError` | Install the target Python module in the same interpreter named by `runtime.node.pythonPath`. For a local module, add its parent directory to `pythonImportPath`. |
-| `No IR produced for module` or `tywrap_ir failed.` | Run `pip install tywrap-ir` in that configured Python environment, then rerun generation. |
+| `No IR produced for module ... tywrap_ir failed.` with `ModuleNotFoundError` | Install the target Python module in the same interpreter named by `runtime.node.pythonPath`. For a local module, add its parent directory to `pythonImportPath`. |
+| `No IR produced for module` or `tywrap_ir not found on PYTHONPATH.` | Run `pip install tywrap-ir` in that configured Python environment, then rerun generation. |
 | `IR version mismatch:` or `ir-version-mismatch` | Upgrade `tywrap-ir` to match `tywrap`, then regenerate the contract. |
 | `contract-invalid` or `Contract ... is missing` | Replace the invalid or stale `contractInput` with a regenerated contract. |
 | `Generated wrappers are out of date:` | Run `npx tywrap generate`, review the wrapper and contract changes, and commit them. |
@@ -3358,8 +3358,8 @@ promise resolves.
 
 `NodeBridge` starts `runtime/python_bridge.py` through the subprocess transport.
 Normal requests and responses are JSONL. When a request or response crosses the
-line ceiling, `src/runtime/frame-codec.ts` splits it into negotiated
-`tywrap-frame/1` frames. Reassembly remains bounded by the codec payload limit.
+line ceiling, `src/runtime/frame-codec.ts` splits it into `tywrap-frame/1`
+frames. Reassembly remains bounded by the codec payload limit.
 
 `PyodideBridge` runs the shared Python bridge core in WebAssembly. Its generated
 bootstrap source lives in `src/runtime/pyodide-bootstrap-core.generated.ts`; do

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -3330,7 +3330,7 @@ the declared return schema.
 | Python analysis | `tywrap_ir/tywrap_ir/__main__.py`, `tywrap_ir/tywrap_ir/` | The extractor emits JSON typed IR for the requested module. |
 | IR contract | `src/tywrap.ts`, `src/types/` | A contract has the expected module and `ir_version`. The current version is `0.4.0`. |
 | Wrapper generation | `src/core/generator.ts`, `src/core/emit-call.ts`, `src/core/mapper.ts` | Generated calls carry a `ReturnSchema` that represents the Python return annotation. |
-| Runtime transport | `src/runtime/node.ts`, `src/runtime/subprocess-transport.ts`, `src/runtime/frame-codec.ts`, `runtime/python_bridge.py` | Node subprocess requests use JSONL and negotiate `tywrap-frame/1` when a message exceeds one line. |
+| Runtime transport | `src/runtime/node.ts`, `src/runtime/subprocess-transport.ts`, `src/runtime/frame-codec.ts`, `runtime/python_bridge.py` | Node subprocess requests use JSONL and use `tywrap-frame/1` when a message exceeds one line. |
 | Python dispatch and encoding | `runtime/tywrap_bridge_core.py`, `runtime/safe_codec.py` | The bridge validates protocol input, then dispatches the requested call and returns JSON-safe values or versioned envelopes. |
 | JavaScript decoding | `src/utils/codec.ts`, `src/runtime/bridge-codec.ts` | Envelope shape and payload domains are checked before a decoded value reaches application code. |
 | Return validation | `src/runtime/validators.ts` | A decoded result matches the generated `ReturnSchema`, including scientific provenance when declared. |

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -457,6 +457,141 @@ const [sinValue, cosValue, tanValue] = await Promise.all([
 
 ---
 
+<!-- Source: docs/guide/agent-adoption.md -->
+# Agent Adoption
+
+Use `NodeBridge` for a TypeScript project that can start a local Python
+process. Use `PyodideBridge` for browser code. Use `HttpBridge` when Python
+runs on another host. See the [runtime comparison](https://bbopen.github.io/tywrap/guide/runtimes/comparison) for
+constraints such as Deno Deploy and Arrow support.
+
+## Recipe
+
+Run these commands from the TypeScript project root. Replace `math` with the
+Python module the project must call.
+
+```bash
+npm install tywrap
+```
+
+Expected output includes an added `tywrap` dependency in `package.json`.
+
+```bash
+pip install tywrap-ir
+```
+
+Expected output ends with a successful `tywrap-ir` installation. This `pip`
+must install into the same Python environment configured below.
+
+```bash
+npx tywrap init
+```
+
+Expected output:
+
+```text
+Created /absolute/path/to/project/tywrap.config.ts
+```
+
+The command writes this starter configuration and adds `tywrap:generate` and
+`tywrap:check` scripts when `package.json` exists:
+
+```ts
+import { defineConfig } from 'tywrap';
+
+export default defineConfig({
+  pythonModules: {
+    math: { typeHints: 'strict' },
+  },
+  output: {
+    dir: './generated',
+    format: 'esm',
+    declaration: false,
+    sourceMap: false,
+  },
+  runtime: {
+    node: {
+      pythonPath: 'python3',
+    },
+  },
+  types: {
+    presets: ['stdlib'],
+  },
+});
+```
+
+Edit `pythonModules` and `runtime.node.pythonPath` as needed. A local module
+also needs its parent directory in `pythonImportPath`.
+
+```bash
+npx tywrap generate
+```
+
+Expected output for one module:
+
+```text
+Generated: 2 files from 1 modules (warnings: 0).
+- generated/math.generated.ts
+- generated/math.contract.json
+```
+
+The wrapper is `<module>.generated.ts`. The pinned extractor output is
+`<module>.contract.json`. Import the compiled wrapper, set the bridge once,
+then call the wrapper:
+
+```ts
+import { NodeBridge } from 'tywrap/node';
+import { setRuntimeBridge } from 'tywrap/runtime';
+import * as math from './generated/math.generated.js';
+
+setRuntimeBridge(new NodeBridge({ pythonPath: 'python3' }));
+
+const value = await math.sqrt(16);
+console.log(value); // 4
+```
+
+Expected output:
+
+```text
+4
+```
+
+## Verify generated output
+
+Commit the wrapper and contract files, then check them in CI:
+
+```bash
+npx tywrap generate --check
+```
+
+Expected output when current:
+
+```text
+Generated wrappers are up to date.
+```
+
+Exit code `0` means all generated files match. Exit code `1` means generation
+failed, including a missing configuration or Python import failure. Exit code
+`2` means `--fail-on-warn` found warnings. Exit code `3` means generated files
+or contracts differ; run `npx tywrap generate` and commit the result. See the
+[CLI reference](https://bbopen.github.io/tywrap/reference/cli) for the complete command surface.
+
+## Failure signatures
+
+| Error prefix or text | Fix |
+| --- | --- |
+| `IR extraction failed` or `ModuleNotFoundError` | Install the target Python module in the same interpreter named by `runtime.node.pythonPath`. For a local module, add its parent directory to `pythonImportPath`. |
+| `No IR produced for module` or `tywrap_ir failed.` | Run `pip install tywrap-ir` in that configured Python environment, then rerun generation. |
+| `IR version mismatch:` or `ir-version-mismatch` | Upgrade `tywrap-ir` to match `tywrap`, then regenerate the contract. |
+| `contract-invalid` or `Contract ... is missing` | Replace the invalid or stale `contractInput` with a regenerated contract. |
+| `Generated wrappers are out of date:` | Run `npx tywrap generate`, review the wrapper and contract changes, and commit them. |
+| `Received an Arrow-encoded payload but no Arrow decoder is available.` | Run `npm install apache-arrow`, or set `TYWRAP_CODEC_FALLBACK=json` on the Python side when its documented JSON domain is acceptable. |
+| `JSON pandas.DataFrame encoding requires an unnamed RangeIndex` or `JSON pandas.Series encoding requires an unnamed RangeIndex` | Follow the recipe in the error, such as `.reset_index(drop=True)`, or use Arrow. Other JSON codec preflight errors also state their conversion recipe. Apply that recipe rather than suppressing the error. |
+| `Return validation failed for` (`BridgeValidationError`) | Compare the Python return value with the generated declared type. The message gives the call site and describes the expected type and received shape. Fix the annotation or returned value, then regenerate. |
+| `Response payload is ... exceeds TYWRAP_CODEC_MAX_BYTES=` | Raise `TYWRAP_CODEC_MAX_BYTES` only for a response size the process can handle, or return a smaller result. |
+
+---
+
 <!-- Source: docs/guide/configuration.md -->
 # Configuration
 
@@ -2367,6 +2502,23 @@ Every scientific envelope has these fields:
 - `codecVersion` is `1`. Decoders treat a missing version as legacy version `0`.
 - `encoding` identifies the payload representation.
 
+Scientific values can appear at the root of a result or inside nested Python
+dictionaries, lists, and tuples. The Python bridge replaces each recognized
+value with its envelope. The JavaScript codec then walks plain objects and
+arrays and decodes recognized envelopes within the traversal bounds. A decoded
+envelope is a terminal value, so fields inside its decoded output are not
+scanned again. A `torch.tensor` envelope is the exception because its `value`
+field is a required nested ndarray envelope.
+
+Serialization accepts a maximum nesting depth of 900 and at most 1,000,000
+visited containers. Decoding accepts a maximum depth of 2048 and the same
+1,000,000-container limit. Scientific envelopes count as containers, including
+the ndarray nested inside a tensor. Primitive leaves and the elements of a
+decoded envelope payload do not consume the container limit. The bridge reports
+the result path when a serialization bound is exceeded, and the JavaScript
+codec does the same for decoding bounds. The bridge also rejects circular
+Python containers.
+
 ### SciPy sparse
 
 Supported targets are `scipy.sparse.csr_matrix`, `csc_matrix`, and
@@ -2417,7 +2569,8 @@ The target is `torch.Tensor`. CPU tensors work by default. Schema sketch:
     "encoding": "arrow" | "json",
     "b64": "...",        // when encoding="arrow"
     "data": [ ... ],     // when encoding="json"
-    "shape": [ ... ]
+    "shape": [ ... ],
+    "dtype": "float32"
   }
 }
 ```
@@ -2455,8 +2608,24 @@ pyarrow is not available in WASM.
 
 If an Arrow payload arrives without the dependency, decoding fails with an
 installation hint. Set `TYWRAP_CODEC_FALLBACK=json` on the Python side when a
-JSON fallback is acceptable. JSON fallback is lossy for dtype and missing-value
-fidelity.
+JSON representation is acceptable.
+
+An ndarray JSON envelope includes `shape`, `dtype`, and plain JSON `data`. The
+decoder checks that the data matches the declared shape and supported dtype
+domain. It returns plain JavaScript arrays, or a scalar for a zero-dimensional
+array. The `dtype` field records provenance for validation; it does not create a
+typed JavaScript array. JSON encoding rejects ndarray dtypes and values that it
+cannot represent safely, including complex, structured, object, byte-string,
+unicode, datetime, timedelta, big-endian, and unsafe integer cases.
+
+DataFrame and Series JSON envelopes are values-only representations. Before
+encoding, the bridge requires an unnamed `RangeIndex` starting at 0 with step 1.
+It rejects a `MultiIndex`, categorical dtype, unsupported cell values, unsafe
+integers, non-finite floats, duplicate DataFrame column labels, and labels that
+collide after JSON object-key coercion. `None`, `pd.NA`, and `pd.NaT` become
+JSON `null`. Supported booleans, numbers, strings, empty values, and nulls keep
+their value semantics, but pandas dtype and index metadata are not retained as
+they are with Arrow.
 
 ## Size limits and transport framing
 
@@ -2481,10 +2650,11 @@ their promises resolve. A result that does not match its declared return type
 throws `BridgeValidationError` with the declared type, received shape, and call
 site.
 
-Columnar values retain their decoded provenance. Validation checks the envelope
-marker, dimensions, and dtype for DataFrame, Series, and ndarray returns
-without walking Arrow data. Returns declared as `unknown`, `void`, or `Any` do
-not receive a runtime check.
+Decoded scientific values retain their envelope provenance. Return validation
+recognizes all six markers: `ndarray`, `dataframe`, `series`, `scipy.sparse`,
+`torch.tensor`, and `sklearn.estimator`. It checks the marker and, when present
+in the return contract, dimensions and dtype without walking Arrow data. Returns
+declared as `unknown`, `void`, or `Any` do not receive a runtime check.
 
 ---
 
@@ -3142,6 +3312,179 @@ interface TywrapOptions {
 ```
 
 For the full exported type surface, see `src/index.ts`.
+
+---
+
+<!-- Source: docs/maintainers/architecture.md -->
+# Architecture
+
+tywrap has a generation pipeline and a runtime pipeline. The generation
+pipeline turns Python declarations into TypeScript wrappers. The runtime
+pipeline executes a generated call and returns a decoded result that must match
+the declared return schema.
+
+## Pipeline
+
+| Stage | Owners | Invariant |
+| --- | --- | --- |
+| Python analysis | `tywrap_ir/tywrap_ir/__main__.py`, `tywrap_ir/tywrap_ir/` | The extractor emits JSON typed IR for the requested module. |
+| IR contract | `src/tywrap.ts`, `src/types/` | A contract has the expected module and `ir_version`. The current version is `0.4.0`. |
+| Wrapper generation | `src/core/generator.ts`, `src/core/emit-call.ts`, `src/core/mapper.ts` | Generated calls carry a `ReturnSchema` that represents the Python return annotation. |
+| Runtime transport | `src/runtime/node.ts`, `src/runtime/subprocess-transport.ts`, `src/runtime/frame-codec.ts`, `runtime/python_bridge.py` | Node subprocess requests use JSONL and negotiate `tywrap-frame/1` when a message exceeds one line. |
+| Python dispatch and encoding | `runtime/tywrap_bridge_core.py`, `runtime/safe_codec.py` | The bridge validates protocol input, then dispatches the requested call and returns JSON-safe values or versioned envelopes. |
+| JavaScript decoding | `src/utils/codec.ts`, `src/runtime/bridge-codec.ts` | Envelope shape and payload domains are checked before a decoded value reaches application code. |
+| Return validation | `src/runtime/validators.ts` | A decoded result matches the generated `ReturnSchema`, including scientific provenance when declared. |
+
+## IR and generated contracts
+
+`generate()` in `src/tywrap.ts` invokes `python -m tywrap_ir --module <name>`.
+It validates the returned object before passing it to `CodeGenerator`. The
+generator writes `<module>.generated.ts` and the stable
+`<module>.contract.json` file beside it. The contract omits extractor metadata,
+sorts object keys, and records the pinned IR representation.
+
+`contractInput` changes the source of IR. Instead of starting Python, generation
+reads a saved contract and applies the same module and version validation. This
+supports reproducible generation. A version mismatch is a hard failure: update
+the matching package pair and regenerate the contract.
+
+`src/core/generator.ts` maps annotations to TypeScript and emits one
+`createReturnValidator()` call per generated callable. Return schemas cover
+primitive values, containers, definitions, and scientific markers. The
+wrapper calls the active bridge and validates the resolved value before its
+promise resolves.
+
+## Runtime bridges
+
+`NodeBridge` starts `runtime/python_bridge.py` through the subprocess transport.
+Normal requests and responses are JSONL. When a request or response crosses the
+line ceiling, `src/runtime/frame-codec.ts` splits it into negotiated
+`tywrap-frame/1` frames. Reassembly remains bounded by the codec payload limit.
+
+`PyodideBridge` runs the shared Python bridge core in WebAssembly. Its generated
+bootstrap source lives in `src/runtime/pyodide-bootstrap-core.generated.ts`; do
+not edit it directly. Regenerate it from `runtime/tywrap_bridge_core.py` with
+the repository script. Pyodide uses JSON codec envelopes because pyarrow is not
+available in WASM.
+
+`HttpBridge` sends the same RPC and codec concepts to a remote Python service.
+The transport owns HTTP concerns while the codec and return validator preserve
+the client-side invariants.
+
+## Codec envelopes
+
+`runtime/tywrap_bridge_core.py` recognizes scientific values and replaces them
+with envelopes marked by `__tywrap__`, `codecVersion: 1`, and an `encoding`.
+The marker set is `ndarray`, `dataframe`, `series`, `scipy.sparse`,
+`torch.tensor`, and `sklearn.estimator`. `src/utils/codec.ts` is the matching
+decoder and validates each envelope before decoding it.
+
+Arrow is the default for scientific arrays and pandas tabular values when
+Python has pyarrow and JavaScript has an Arrow decoder. JSON fallback is
+explicit through `TYWRAP_CODEC_FALLBACK=json`; it has narrower, documented
+domains. Pandas JSON values require an unnamed zero-based
+`RangeIndex`, and unsupported dtypes fail with a conversion recipe.
+
+Nested arrays and plain objects can contain envelopes. The producer permits a
+depth of 900 and at most 1,000,000 visited containers. The decoder permits a
+depth of 2048 and the same container count. The budget excludes primitive
+leaves. A decoded envelope is terminal, except for
+the required nested ndarray inside a torch envelope.
+
+## Runtime return validation
+
+`src/runtime/validators.ts` validates the value after decoding. A mismatch
+throws `BridgeValidationError` with the call site, declared type, and received
+shape. Scientific values retain non-enumerable provenance from their envelope.
+The validator checks the marker and, when the schema declares them, dimensions
+and dtype without walking Arrow payload data. `unknown`, `void`, and `Any`
+returns deliberately receive no runtime check.
+
+## One call end to end
+
+1. A generated call such as `math.sqrt(16)` builds a bridge request and its
+   generated `ReturnSchema` validator.
+2. `NodeBridge` sends the request over JSONL, or `tywrap-frame/1` frames when
+   it is too large for one line.
+3. `runtime/python_bridge.py` reads the request and calls
+   `dispatch_request()` in `runtime/tywrap_bridge_core.py`.
+4. The core imports the requested module, dispatches `sqrt`, and serializes its
+   result. A scientific result becomes a version-1 envelope; a plain number
+   remains JSON.
+5. The subprocess transport returns the response. `BridgeCodec` and
+   `decodeEnvelopeAsync()` validate and decode its value.
+6. The generated return validator accepts the decoded number and resolves the
+   promise. A mismatched value throws `BridgeValidationError` instead.
+
+Read [Scientific Codec Envelopes](https://bbopen.github.io/tywrap/codec-envelopes) before changing an
+envelope. It defines the supported JSON domains and validation behavior.
+
+---
+
+<!-- Source: docs/maintainers/menagerie.md -->
+# Menagerie Discipline
+
+The menagerie is the executable truth table for generation and codec behavior.
+Its catalogue is `test/menagerie/manifest.ts`. It contains rows rather
+than a claim that a broad type family works.
+
+## A row
+
+A runtime catalogue row describes one Python call under one codec path. It has
+an `id`, fixture, call, expected result or error, status, and optional package
+requirements. A row can select Arrow or JSON fallback. The test runs the call
+through `NodeBridge`. It does not test a serializer in isolation.
+
+The generation gate also generates and typechecks the tier-one fixture modules.
+Optional-library tests add cases that require installed scientific packages.
+
+## Statuses
+
+| Status | Meaning | Obligation |
+| --- | --- | --- |
+| `EXPECTED_OK` | The call preserves the stated result. | Assert the exact value or declared structural expectation. |
+| `KNOWN_LIE` | The current transport resolves but loses stated semantics. | Record the observed result and an `expectedFix`. Do not describe the behavior as lossless. |
+| `LOUD_FAIL` | The call must reject at the bridge boundary. | Supply an error expectation. The test checks that error rows and this status stay aligned. |
+
+`KNOWN_LIE` is documentation of a measured limitation, not a passing result to
+silently improve. `LOUD_FAIL` is a contract that a value outside the supported
+domain fails with an error that states the cause.
+
+## Add or change a row
+
+1. Add the fixture function in `test/menagerie/fixtures/` when needed.
+2. Add one catalogue row in `test/menagerie/manifest.ts` with the codec,
+   status, current behavior, and expectation.
+3. Declare every optional library in `requires` and any feature condition in
+   `featureProbe`.
+4. Run `npm run test:menagerie` with the pinned dependencies below.
+5. Update generated snapshots when the generation gate intentionally changes.
+
+When behavior changes, flip the rows in the same PR. A fix that turns a
+lossy result into a preserved result changes `KNOWN_LIE` to `EXPECTED_OK`; a
+newly supported representation needs its own row. Do not leave the
+catalogue describing yesterday's behavior.
+
+## Pinned scientific job
+
+GitHub Actions runs `optional-scientific-menagerie` on Python 3.11 and Node 22.
+It installs `tywrap_ir`, then pins NumPy 2.3.5, pandas 3.0.2, pyarrow 24.0.0,
+SciPy 1.16.3, scikit-learn 1.8.0, and CPU-only torch 2.10.0. The pins make a
+truth-table change reviewable rather than a moving dependency result.
+
+Run the same gate locally in a fresh virtual environment:
+
+```bash
+python3.11 -m venv .venv-menagerie
+.venv-menagerie/bin/python -m pip install -e tywrap_ir
+.venv-menagerie/bin/python -m pip install numpy==2.3.5 pandas==3.0.2 pyarrow==24.0.0 scipy==1.16.3 scikit-learn==1.8.0
+.venv-menagerie/bin/python -m pip install torch==2.10.0 --index-url https://download.pytorch.org/whl/cpu
+TYWRAP_CODEC_PYTHON=.venv-menagerie/bin/python npm run test:menagerie
+```
+
+The test skips a row only when its declared optional dependency or feature
+probe is unavailable. The pinned CI job provides the expected scientific
+surface for review.
 
 ---
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -11,6 +11,7 @@
 ## Docs
 
 - [Getting Started](https://bbopen.github.io/tywrap/guide/getting-started): Installation, quick start, first wrapper
+- [Agent Adoption](https://bbopen.github.io/tywrap/guide/agent-adoption): Deterministic project-adoption recipe for coding agents
 - [Configuration](https://bbopen.github.io/tywrap/guide/configuration): tywrap.config.ts / .json, all options
 - [Runtime Comparison](https://bbopen.github.io/tywrap/guide/runtimes/comparison): Which bridge to use and when
 - [Node.js Runtime](https://bbopen.github.io/tywrap/guide/runtimes/node): NodeBridge setup, virtual envs, pooling, large-payload chunking

--- a/examples/living-app/README.md
+++ b/examples/living-app/README.md
@@ -6,9 +6,10 @@ This is a small but non-trivial “living example” that exercises tywrap end-t
 - Python uses `pandas` + `numpy` for data work and `pydantic` for config validation
 - Rich results (e.g. `pandas.DataFrame`) come back via Arrow IPC and are decoded in Node with `apache-arrow` (auto-registered by `NodeBridge`)
 
-## What it does
+## Overview
 
-The example generates two synthetic CSV datasets (“baseline” and “current”), profiles them, and produces a simple drift report.
+The example creates two synthetic CSV datasets: “baseline” and “current”. It
+profiles them and returns a simple drift report.
 
 ## Setup (fresh checkout)
 

--- a/scripts/generate-llms-full.mjs
+++ b/scripts/generate-llms-full.mjs
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 const orderedDocs = [
   'docs/index.md',
   'docs/guide/getting-started.md',
+  'docs/guide/agent-adoption.md',
   'docs/guide/configuration.md',
   'docs/guide/runtimes/comparison.md',
   'docs/guide/runtimes/node.md',
@@ -19,6 +20,8 @@ const orderedDocs = [
   'docs/transport-capabilities.md',
   'docs/transport-framing.md',
   'docs/reference/api/index.md',
+  'docs/maintainers/architecture.md',
+  'docs/maintainers/menagerie.md',
   'docs/examples/index.md',
   'docs/troubleshooting/index.md',
 ];


### PR DESCRIPTION
## Summary

Docs-only PR from the full write-like-a-human sweep and structural audit. The docs now serve their two primary audiences directly: coding agents adopting tywrap in a user's project, and maintainers of tywrap itself.

New pages:
- `docs/guide/agent-adoption.md` — deterministic adoption recipe: command sequence with real expected output at each step (verified by running the actual CLI), bridge decision rule, `generate --check` exit-code semantics, and a failure-signature table mapping verbatim error prefixes to fixes.
- `docs/maintainers/architecture.md` — pipeline overview (IR extraction, contract, generation, bridges, envelopes, return validation) with each stage's owning files and invariant, plus an end-to-end call trace.
- `docs/maintainers/menagerie.md` — the truth-table discipline: three statuses with their obligations, the named-row flip rule, local setup with pinned versions.

Changed:
- `CONTRIBUTING.md` expanded into a maintainer entry point (test map, generated-file rules, prose gate, release pointer).
- `README.md` gains a short "For coding agents" section pointing at llms.txt and the adoption guide; a stale per-module runtime example fixed.
- Residual prose fixes in `AGENTS.md`/`CLAUDE.md` (kept synchronized) and the living-app README.
- VitePress sidebar, `llms.txt`, and the llms-full bundle wired; `llms-full.txt` regenerated.

## Verification

- Independent fact-check ran the real CLI flow in a scratch project: init/generate/--check outputs and every quoted error prefix verified against source. Five discrepancies found and corrected (including the honest `warnings: 1` for the math example).
- `npm run docs:build` exit 0; sloplint pattern layer clean on all touched files.