### PR TITLE
docs: bump version stamps from 0.9 to 0.10

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -59,7 +59,7 @@ console.log(await sin(pi / 4));
 
 ## Value-returning APIs
 
-v0.9 generated wrappers do not keep live Python class instances. Expose an
+v0.10 generated wrappers do not keep live Python class instances. Expose an
 operation as a value-returning module function instead:
 
 ```ts

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -174,7 +174,7 @@ types: {
 ```
 
 Accepted presets are `numpy`, `pandas`, `pydantic`, `stdlib`, `scipy`, `torch`,
-and `sklearn`. `numpy` is accepted as a no-op in 0.9.0. The other presets map
+and `sklearn`. `numpy` is accepted as a no-op in 0.10.0. The other presets map
 the library types implemented by the generator, such as `DataFrame`, sparse
 matrix classes, `Tensor`, and `BaseEstimator`.
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -321,7 +321,7 @@ and `tywrap:check` scripts to `package.json` (disable with `--no-scripts`).
 1. Set `"caching": true` to reuse generation IR across rebuilds.
 2. Limit `functions` and `classes` when a wrapper needs only part of a module.
 
-`batching` and `compression` are accepted config fields in 0.9.0, but no current
+`batching` and `compression` are accepted config fields in 0.10.0, but no current
 generator or runtime code applies them.
 
 ```json

--- a/docs/reference/type-mapping.md
+++ b/docs/reference/type-mapping.md
@@ -187,7 +187,7 @@ Generates TypeScript shaped like:
 export type Pair<T> = [T, T];
 export type Transform<P extends unknown[], T> = (...args: P) => T;
 export class Container<T> {
-  // NOTE: Instance members are not generated in v0.9; migrate this API to value-returning module functions.
+  // NOTE: Instance members are not generated in v0.10; migrate this API to value-returning module functions.
 }
 ```
 

--- a/docs/transport-capabilities.md
+++ b/docs/transport-capabilities.md
@@ -82,7 +82,7 @@ so a payload can exceed the JSONL line ceiling. The capability is statically
 [Transport framing](./transport-framing.md) for the wire format.
 
 `supportsStreaming` (incremental results for a single request) is `false` on
-every backend. It is not implemented as of 0.9.0.
+every backend. It is not implemented as of 0.10.0.
 
 ### `maxFrameBytes`
 

--- a/docs/transport-framing.md
+++ b/docs/transport-framing.md
@@ -17,7 +17,7 @@ through a `PooledTransport` lease reassembles correctly (see
 
 ## Scope: subprocess only
 
-`tywrap-frame/1` is **subprocess-only** as of 0.9.0. The subprocess transport is
+`tywrap-frame/1` is **subprocess-only** as of 0.10.0. The subprocess transport is
 the only backend with a real frame ceiling, the JSONL line-length limit. The
 other backends stay single-frame and keep `supportsChunking: false`:
 
@@ -27,7 +27,7 @@ other backends stay single-frame and keep `supportsChunking: false`:
 - **Pyodide** is in-memory (`maxFrameBytes: Number.POSITIVE_INFINITY`,
   JSON-only). There is no wire to fragment.
 
-`supportsStreaming` stays `false` on every backend as of 0.9.0.
+`supportsStreaming` stays `false` on every backend as of 0.10.0.
 
 ## Layering
 
@@ -106,7 +106,7 @@ construction. The codepoint-boundary rule is a sender obligation: a frame's
 `data` MUST NOT split a multi-byte UTF-8 sequence, so the receiver can decode
 each frame as valid UTF-8 and concatenate without re-aligning bytes across frame
 edges. `utf8-base64` remains a defined alternative in the wire schema for future
-use (e.g. a non-text payload), but tywrap does not emit it as of 0.9.0.
+use (e.g. a non-text payload), but tywrap does not emit it as of 0.10.0.
 
 > Implementation note for later workstreams: `total` and the per-frame split
 > points are computed over the message's UTF-8 **byte** length against


### PR DESCRIPTION
Updates the eight "as of 0.9.0" / "in v0.9" stamps across six docs pages to 0.10.0. Each claim was verified against current source before bumping: supportsStreaming is still false on every backend, batching/compression are still validated-but-unapplied config fields, the numpy preset is still an explicit no-op, tywrap-frame/1 is still subprocess-only, and instance members are still not generated.